### PR TITLE
fix: Change target to es2017 with lib esnext

### DIFF
--- a/tsconfig-generators-only.json
+++ b/tsconfig-generators-only.json
@@ -2,13 +2,16 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "esnext",
+    "target": "es2017",
     "module": "commonjs",
     "sourceMap": true,
     "declaration": true,
     "importHelpers": true,
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": [
+      "esnext"
+    ],
   },
   "include": [
     "./src/lib/generators/*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,16 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "esnext",
+    "target": "es2017",
     "module": "commonjs",
     "sourceMap": true,
     "declaration": true,
     "importHelpers": true,
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": [
+      "esnext"
+    ],
   },
   "include": ["./src/lib/**/*"]
 }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Removes the node 14 dependency and make it compatible with v12.x

