### PR TITLE
feat: Add abstraction methods inject mechanism and vulnpaths helper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,9 @@ jobs:
             - run: npm run build-generators-only
             - run: npm run convert-to-swagger
             - run: npm run prepare-swagger
-            - run: npm run generate-classes test
+            - run: npm run generate-classes
+            - run: npm run build-generators-and-abstraction
+            - run: npm run generate-classes
             - run: npm run format
             - run: npm run build
             - run: npm run generate-test-cases
@@ -40,6 +42,8 @@ jobs:
             - run: npm run build-generators-only
             - run: npm run convert-to-swagger
             - run: npm run prepare-swagger
+            - run: npm run generate-classes test
+            - run: npm run build-generators-and-abstraction
             - run: npm run generate-classes test
             - run: npm run format
             - run: npm run build

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "test:watch": "tsc-watch --onSuccess 'npm run test:unit'",
     "build": "tsc",
     "build-generators-only": "tsc --project tsconfig-generators-only.json",
-    "build-and-generate-and-format": "npm run build-generators-only && npm run generate-classes && npm run generate-test-cases && npm run generate-test-fixtures && npm run format",
-    "build-and-generate-for-test-and-format": "npm run build-generators-only && npm run generate-classes test && npm run generate-test-cases && npm run generate-test-fixtures && npm run format",
+    "build-generators-and-abstraction": "tsc --project tsconfig-generators-and-abstraction.json",
+    "build-and-generate-and-format": "npm run build-generators-only && npm run generate-classes test && npm run build-generators-and-abstraction && npm run generate-classes && npm run generate-test-cases && npm run generate-test-fixtures && npm run format",
+    "build-and-generate-for-test-and-format": "npm run build-generators-only && npm run generate-classes test && npm run build-generators-and-abstraction && npm run generate-classes test && npm run generate-test-cases && npm run generate-test-fixtures && npm run format",
     "build-watch": "tsc -w",
     "prepare": "npm run snyk-protect",
     "snyk-test": "snyk test",
@@ -47,6 +48,7 @@
   "dependencies": {
     "@manifoldco/swagger-to-ts": "^2.0.0",
     "@snyk/configstore": "^3.2.0-rc1",
+    "@snyk/dep-graph": "^1.23.0",
     "@types/lodash": "^4.14.155",
     "@types/node": "^14.0.12",
     "axios": "^0.21.1",
@@ -58,7 +60,8 @@
     "snyk-request-manager": "1.3.1",
     "source-map-support": "^0.5.16",
     "tslib": "^1.10.0",
-    "typescript": "^3.9.5"
+    "typescript": "^3.9.5",
+    "utility-types": "^3.10.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.1",
@@ -66,10 +69,12 @@
     "@types/node": "^12.12.26",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",
+    "axios-mock-adapter": "^1.19.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
     "jest": "^25.1.0",
     "jest-mock-axios": "^4.2.0",
+    "nock": "^13.0.7",
     "prettier": "2.0.5",
     "sleep-promise": "^8.0.1",
     "ts-jest": "^25.1.0",

--- a/src/lib/client/abstraction/org/aggregatedissues.ts
+++ b/src/lib/client/abstraction/org/aggregatedissues.ts
@@ -1,0 +1,80 @@
+import { Org, Project } from '../../generated/org';
+import { createFromJSON, DepGraph, DepGraphData } from '@snyk/dep-graph';
+
+interface IssuesWithVulnsPaths {
+  issues: {
+    pkgVersions: { [key: string]: Array<Array<string>> };
+  }[];
+}
+
+export type AggregatedIssuesWithVulnPaths = IssuesWithVulnsPaths &
+  Project.AggregatedissuesPostResponseType;
+
+export const getAggregatedIssuesWithVulnPaths = async (
+  classContext: Object,
+  body: Project.AggregatedissuesPostBodyType,
+): Promise<AggregatedIssuesWithVulnPaths> => {
+  const projectAggregatedIssues = await new Org({
+    orgId: Object(classContext)['orgId'],
+  })
+    .project({ projectId: Object(classContext)['projectId'] })
+    .aggregatedissues.post(body);
+
+  const projectDepGraph = await new Org({
+    orgId: Object(classContext)['orgId'],
+  })
+    .project({ projectId: Object(classContext)['projectId'] })
+    .depgraph.get();
+
+  const depGraph = createFromJSON(projectDepGraph.depGraph as DepGraphData);
+  let returnData: AggregatedIssuesWithVulnPaths = {
+    issues: [],
+  };
+
+  // @ts-ignore
+  projectAggregatedIssues.issues.map((issue) => {
+    // @ts-ignore
+    const versionsWithVulnPaths = issue.pkgVersions.map((version) => {
+      const pkg = {
+        name: issue.pkgName,
+        version: version as string,
+      };
+      const returnData = {
+        [`${pkg.version}`]: getVulnPathsForPkgVersionFromGraph(
+          pkg.name,
+          pkg.version,
+          depGraph,
+        ),
+      };
+      return returnData;
+    });
+
+    const newIssue = {
+      ...issue,
+    };
+    newIssue.pkgVersions = versionsWithVulnPaths;
+    returnData.issues.push(newIssue);
+  });
+
+  return returnData;
+};
+
+const getVulnPathsForPkgVersionFromGraph = (
+  pkgName: string,
+  version: string,
+  depGraph: DepGraph,
+): Array<Array<string>> => {
+  const pkg = {
+    name: pkgName,
+    version: version,
+  };
+  const pkgVulnPaths = depGraph.pkgPathsToRoot(pkg) as Array<
+    Array<{ name: string; version?: string }>
+  >;
+  return pkgVulnPaths.map((vulnPath) =>
+    vulnPath
+      .map((vulnPathPkg) => `${vulnPathPkg.name}@${vulnPathPkg.version}`)
+      .reverse()
+      .slice(1),
+  );
+};

--- a/test/abstraction/org/aggregatedissues.test.ts
+++ b/test/abstraction/org/aggregatedissues.test.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Org } from '../../../src/lib';
+import * as _ from 'lodash';
+import nock from 'nock';
+jest.unmock('axios');
+
+const aggregatedIssuesFixtures = fs.readFileSync(
+  path.resolve(__dirname, '../..') +
+    '/fixtures/abstraction/org/aggregatedIssues-goof.json',
+);
+const depGraphFixtures = fs.readFileSync(
+  path.resolve(__dirname, '../..') +
+    '/fixtures/abstraction/org/depgraph-goof.json',
+);
+const aggregatedIssuesWithVulnFixtures = fs.readFileSync(
+  path.resolve(__dirname, '../..') +
+    '/fixtures/abstraction/org/aggregatedIssuesWithVulnPaths-goof.json',
+);
+
+beforeAll(() => {
+  return nock('https://snyk.io')
+    .persist()
+    .post(/.*/)
+    .reply(200, () => {
+      return aggregatedIssuesFixtures;
+    })
+    .get(/.*/)
+    .reply(200, () => {
+      return depGraphFixtures;
+    });
+});
+
+describe('Testing org abstraction ', () => {
+  it('Testing getAggregatedIssuesWithVulnsPaths', async () => {
+    const body = { filters: {} };
+
+    const result = await new Org({ orgId: '123' })
+      .project({ projectId: '123' })
+      .aggregatedissues.getAggregatedIssuesWithVulnPaths(body);
+    expect(
+      _.isEqual(
+        result,
+        JSON.parse(aggregatedIssuesWithVulnFixtures.toString()),
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/test/fixtures/abstraction/org/aggregatedIssues-goof.json
+++ b/test/fixtures/abstraction/org/aggregatedIssues-goof.json
@@ -1,0 +1,984 @@
+{
+  "issues": [
+    {
+      "id": "SNYK-JS-EXPRESSFILEUPLOAD-473997",
+      "issueType": "vuln",
+      "pkgName": "express-fileupload",
+      "pkgVersions": ["0.0.5"],
+      "priorityScore": 704,
+      "priority": {
+        "score": 704,
+        "factors": [
+          {
+            "name": "isFixable",
+            "description": "Has a fix available"
+          },
+          {
+            "name": "cvssScore",
+            "description": "CVSS 9.8"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-EXPRESSFILEUPLOAD-473997",
+        "title": "Denial of Service (DoS)",
+        "severity": "high",
+        "url": "https://snyk.io/vuln/SNYK-JS-EXPRESSFILEUPLOAD-473997",
+        "identifiers": {
+          "CVE": [],
+          "CWE": ["CWE-79"],
+          "NSP": [1216],
+          "GHSA": ["GHSA-q3w9-g74q-vp5f"]
+        },
+        "credit": ["Roman Burunkov"],
+        "exploitMaturity": "no-known-exploit",
+        "semver": {
+          "vulnerable": ["<1.1.6-alpha.6"]
+        },
+        "publicationTime": "2019-10-22T15:08:40Z",
+        "disclosureTime": "2019-10-18T11:17:09Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "cvssScore": 9.8,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": true,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-EXPRESSFILEUPLOAD-595969",
+      "issueType": "vuln",
+      "pkgName": "express-fileupload",
+      "pkgVersions": ["0.0.5"],
+      "priorityScore": 696,
+      "priority": {
+        "score": 696,
+        "factors": [
+          {
+            "name": "exploitMaturity",
+            "description": "Proof of Concept exploit"
+          },
+          {
+            "name": "isFixable",
+            "description": "Has a fix available"
+          },
+          {
+            "name": "cvssScore",
+            "description": "CVSS 7.5"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-EXPRESSFILEUPLOAD-595969",
+        "title": "Prototype Pollution",
+        "severity": "high",
+        "url": "https://snyk.io/vuln/SNYK-JS-EXPRESSFILEUPLOAD-595969",
+        "identifiers": {
+          "CVE": ["CVE-2020-7699"],
+          "CWE": ["CWE-400"],
+          "GHSA": ["GHSA-9wcg-jrwf-8gg7"]
+        },
+        "credit": ["po6ix"],
+        "exploitMaturity": "proof-of-concept",
+        "semver": {
+          "vulnerable": ["<1.1.10"]
+        },
+        "publicationTime": "2020-07-30T15:28:18Z",
+        "disclosureTime": "2020-07-29T15:08:59Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+        "cvssScore": 7.5,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": true,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-TREEKILL-536781",
+      "issueType": "vuln",
+      "pkgName": "tree-kill",
+      "pkgVersions": ["1.2.1"],
+      "priorityScore": 671,
+      "priority": {
+        "score": 671,
+        "factors": [
+          {
+            "name": "exploitMaturity",
+            "description": "Proof of Concept exploit"
+          },
+          {
+            "name": "isFixable",
+            "description": "Has a fix available"
+          },
+          {
+            "name": "cvssScore",
+            "description": "CVSS 7"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-TREEKILL-536781",
+        "title": "Command Injection",
+        "severity": "high",
+        "url": "https://snyk.io/vuln/SNYK-JS-TREEKILL-536781",
+        "identifiers": {
+          "CVE": ["CVE-2019-15598", "CVE-2019-15599"],
+          "CWE": ["CWE-78"],
+          "NSP": [1432, 1433]
+        },
+        "credit": ["mik317"],
+        "exploitMaturity": "proof-of-concept",
+        "semver": {
+          "vulnerable": ["<1.2.2"]
+        },
+        "publicationTime": "2019-12-05T10:51:40Z",
+        "disclosureTime": "2019-12-04T19:54:11Z",
+        "CVSSv3": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H/E:P/RL:U/RC:C",
+        "cvssScore": 7,
+        "language": "js",
+        "patches": [
+          {
+            "id": "patch:SNYK-JS-TREEKILL-536781:0",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/tree-kill/20191210/tree-kill_0_0_20191210_e5d66d1fbd4b392294512d4644ac22bdc888573c.patch"
+            ],
+            "version": ">=1.0.0",
+            "comments": [],
+            "modificationTime": "2019-12-11T11:57:51.268946Z"
+          }
+        ],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": true,
+        "isPartiallyFixable": true,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-LODASH-567746",
+      "issueType": "vuln",
+      "pkgName": "lodash",
+      "pkgVersions": ["4.17.15"],
+      "priorityScore": 636,
+      "priority": {
+        "score": 636,
+        "factors": [
+          {
+            "name": "exploitMaturity",
+            "description": "Proof of Concept exploit"
+          },
+          {
+            "name": "isFixable",
+            "description": "Has a fix available"
+          },
+          {
+            "name": "cvssScore",
+            "description": "CVSS 6.3"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-LODASH-567746",
+        "title": "Prototype Pollution",
+        "severity": "medium",
+        "url": "https://snyk.io/vuln/SNYK-JS-LODASH-567746",
+        "identifiers": {
+          "CVE": ["CVE-2020-8203"],
+          "CWE": ["CWE-400"],
+          "NSP": [1523],
+          "GHSA": ["GHSA-p6mc-m468-83gw"]
+        },
+        "credit": ["posix"],
+        "exploitMaturity": "proof-of-concept",
+        "semver": {
+          "vulnerable": ["<4.17.16"]
+        },
+        "publicationTime": "2020-04-28T14:59:14Z",
+        "disclosureTime": "2020-04-27T22:14:18Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:U/RC:C",
+        "cvssScore": 6.3,
+        "language": "js",
+        "patches": [
+          {
+            "id": "patch:SNYK-JS-LODASH-567746:0",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/lodash/20200430/lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+            ],
+            "version": ">=4.14.2",
+            "comments": [],
+            "modificationTime": "2020-04-30T14:28:46.729327Z"
+          }
+        ],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": true,
+        "isPartiallyFixable": true,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-HTTPSPROXYAGENT-469131",
+      "issueType": "vuln",
+      "pkgName": "https-proxy-agent",
+      "pkgVersions": ["2.2.2"],
+      "priorityScore": 626,
+      "priority": {
+        "score": 626,
+        "factors": [
+          {
+            "name": "exploitMaturity",
+            "description": "Proof of Concept exploit"
+          },
+          {
+            "name": "isFixable",
+            "description": "Has a fix available"
+          },
+          {
+            "name": "cvssScore",
+            "description": "CVSS 6.1"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-HTTPSPROXYAGENT-469131",
+        "title": "Man-in-the-Middle (MitM)",
+        "severity": "medium",
+        "url": "https://snyk.io/vuln/SNYK-JS-HTTPSPROXYAGENT-469131",
+        "identifiers": {
+          "CVE": [],
+          "CWE": ["CWE-300"],
+          "NSP": [1184]
+        },
+        "credit": ["Kris Adler"],
+        "exploitMaturity": "proof-of-concept",
+        "semver": {
+          "vulnerable": ["<2.2.3"]
+        },
+        "publicationTime": "2019-10-02T08:08:11Z",
+        "disclosureTime": "2019-09-25T08:21:57Z",
+        "CVSSv3": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N/E:P/RL:U/RC:C",
+        "cvssScore": 6.1,
+        "language": "js",
+        "patches": [
+          {
+            "id": "patch:SNYK-JS-HTTPSPROXYAGENT-469131:0",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/https-proxy-agent/20190929/https-proxy-agent_0_0_20190929.patch"
+            ],
+            "version": "=2.2.1",
+            "comments": [],
+            "modificationTime": "2019-12-03T11:40:45.721480Z"
+          },
+          {
+            "id": "patch:SNYK-JS-HTTPSPROXYAGENT-469131:1",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/https-proxy-agent/20190929/https-proxy-agent_0_1_20190929.patch"
+            ],
+            "version": "=2.2.2",
+            "comments": [],
+            "modificationTime": "2019-12-03T11:40:45.723464Z"
+          }
+        ],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": true,
+        "isPartiallyFixable": true,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "snyk:lic:npm:goof:GPL-2.0",
+      "issueType": "license",
+      "pkgName": "goof",
+      "pkgVersions": ["0.0.3"],
+      "priorityScore": 625,
+      "priority": {
+        "score": 625,
+        "factors": [
+          {
+            "name": "isFresh",
+            "description": "Recently disclosed"
+          },
+          {
+            "name": "severity",
+            "description": "High severity"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "snyk:lic:npm:goof:GPL-2.0",
+        "title": "GPL-2.0 license",
+        "severity": "high",
+        "url": "https://snyk.io/vuln/snyk:lic:npm:goof:GPL-2.0",
+        "exploitMaturity": "no-data",
+        "semver": {
+          "vulnerable": [">=0"]
+        },
+        "publicationTime": "2021-02-01T14:58:40.027Z",
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": false,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-LODASH-590103",
+      "issueType": "vuln",
+      "pkgName": "lodash",
+      "pkgVersions": ["4.17.15"],
+      "priorityScore": 490,
+      "priority": {
+        "score": 490,
+        "factors": [
+          {
+            "name": "cvssScore",
+            "description": "CVSS 9.8"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-LODASH-590103",
+        "title": "Prototype Pollution",
+        "severity": "high",
+        "url": "https://snyk.io/vuln/SNYK-JS-LODASH-590103",
+        "identifiers": {
+          "CVE": [],
+          "CWE": ["CWE-400"]
+        },
+        "credit": ["reeser"],
+        "exploitMaturity": "no-known-exploit",
+        "semver": {
+          "vulnerable": ["<4.17.20"]
+        },
+        "publicationTime": "2020-08-16T13:09:06Z",
+        "disclosureTime": "2020-07-24T12:00:52Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "cvssScore": 9.8,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-Y18N-1021887",
+      "issueType": "vuln",
+      "pkgName": "y18n",
+      "pkgVersions": ["3.2.1"],
+      "priorityScore": 472,
+      "priority": {
+        "score": 472,
+        "factors": [
+          {
+            "name": "exploitMaturity",
+            "description": "Proof of Concept exploit"
+          },
+          {
+            "name": "cvssScore",
+            "description": "CVSS 7.3"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-Y18N-1021887",
+        "title": "Prototype Pollution",
+        "severity": "high",
+        "url": "https://snyk.io/vuln/SNYK-JS-Y18N-1021887",
+        "identifiers": {
+          "CVE": ["CVE-2020-7774"],
+          "CWE": ["CWE-400"]
+        },
+        "credit": ["po6ix"],
+        "exploitMaturity": "proof-of-concept",
+        "semver": {
+          "vulnerable": ["<3.2.2", ">=4.0.0 <4.0.1", ">=5.0.0 <5.0.5"]
+        },
+        "publicationTime": "2020-11-10T15:27:28Z",
+        "disclosureTime": "2020-10-25T14:24:22Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "cvssScore": 7.3,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-LODASH-608086",
+      "issueType": "vuln",
+      "pkgName": "lodash",
+      "pkgVersions": ["4.17.15"],
+      "priorityScore": 472,
+      "priority": {
+        "score": 472,
+        "factors": [
+          {
+            "name": "exploitMaturity",
+            "description": "Proof of Concept exploit"
+          },
+          {
+            "name": "cvssScore",
+            "description": "CVSS 7.3"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-LODASH-608086",
+        "title": "Prototype Pollution",
+        "severity": "high",
+        "url": "https://snyk.io/vuln/SNYK-JS-LODASH-608086",
+        "identifiers": {
+          "CVE": [],
+          "CWE": ["CWE-400"]
+        },
+        "credit": ["awarau"],
+        "exploitMaturity": "proof-of-concept",
+        "semver": {
+          "vulnerable": ["<4.17.17"]
+        },
+        "publicationTime": "2020-08-21T12:53:03Z",
+        "disclosureTime": "2020-08-21T10:34:29Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "cvssScore": 7.3,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-INI-1048974",
+      "issueType": "vuln",
+      "pkgName": "ini",
+      "pkgVersions": ["1.3.5"],
+      "priorityScore": 472,
+      "priority": {
+        "score": 472,
+        "factors": [
+          {
+            "name": "exploitMaturity",
+            "description": "Proof of Concept exploit"
+          },
+          {
+            "name": "cvssScore",
+            "description": "CVSS 7.3"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-INI-1048974",
+        "title": "Prototype Pollution",
+        "severity": "high",
+        "url": "https://snyk.io/vuln/SNYK-JS-INI-1048974",
+        "identifiers": {
+          "CVE": ["CVE-2020-7788"],
+          "CWE": ["CWE-400"],
+          "GHSA": ["GHSA-qqgx-2p2h-9c37"]
+        },
+        "credit": [
+          "Eugene Lim",
+          "Government Technology Agency Cyber Security Group"
+        ],
+        "exploitMaturity": "proof-of-concept",
+        "semver": {
+          "vulnerable": ["<1.3.6"]
+        },
+        "publicationTime": "2020-12-10T18:08:38Z",
+        "disclosureTime": "2020-12-08T13:02:04Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "cvssScore": 7.3,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-DOTPROP-543489",
+      "issueType": "vuln",
+      "pkgName": "dot-prop",
+      "pkgVersions": ["4.2.0"],
+      "priorityScore": 422,
+      "priority": {
+        "score": 422,
+        "factors": [
+          {
+            "name": "exploitMaturity",
+            "description": "Proof of Concept exploit"
+          },
+          {
+            "name": "cvssScore",
+            "description": "CVSS 6.3"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-DOTPROP-543489",
+        "title": "Prototype Pollution",
+        "severity": "medium",
+        "url": "https://snyk.io/vuln/SNYK-JS-DOTPROP-543489",
+        "identifiers": {
+          "CVE": ["CVE-2020-8116"],
+          "CWE": ["CWE-400"]
+        },
+        "credit": ["aaron_costello"],
+        "exploitMaturity": "proof-of-concept",
+        "semver": {
+          "vulnerable": [">1.0.1 <4.2.1", ">=5.0.0 <5.1.1"]
+        },
+        "publicationTime": "2020-01-28T16:23:39Z",
+        "disclosureTime": "2020-01-28T10:17:51Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "cvssScore": 6.3,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "npm:ejs:20161128",
+      "issueType": "vuln",
+      "pkgName": "ejs",
+      "pkgVersions": ["0.8.8"],
+      "priorityScore": 405,
+      "priority": {
+        "score": 405,
+        "factors": [
+          {
+            "name": "cvssScore",
+            "description": "CVSS 8.1"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "npm:ejs:20161128",
+        "title": "Arbitrary Code Execution",
+        "severity": "high",
+        "url": "https://snyk.io/vuln/npm:ejs:20161128",
+        "identifiers": {
+          "CVE": ["CVE-2017-1000228"],
+          "CWE": ["CWE-94"],
+          "ALTERNATIVE": ["SNYK-JS-EJS-10218"]
+        },
+        "credit": ["Snyk Security Research Team"],
+        "exploitMaturity": "no-known-exploit",
+        "semver": {
+          "vulnerable": ["<2.5.3"]
+        },
+        "publicationTime": "2016-11-28T18:44:12Z",
+        "disclosureTime": "2016-11-27T22:00:00Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "cvssScore": 8.1,
+        "language": "js",
+        "patches": [
+          {
+            "id": "patch:npm:ejs:20161128:0",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ejs/20161128/ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+            ],
+            "version": "<2.5.3 >=2.2.4",
+            "comments": [],
+            "modificationTime": "2019-12-03T11:40:45.851976Z"
+          }
+        ],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": false,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-MINIMIST-559764",
+      "issueType": "vuln",
+      "pkgName": "minimist",
+      "pkgVersions": ["1.2.0", "0.0.8", "0.0.10"],
+      "priorityScore": 387,
+      "priority": {
+        "score": 387,
+        "factors": [
+          {
+            "name": "exploitMaturity",
+            "description": "Proof of Concept exploit"
+          },
+          {
+            "name": "cvssScore",
+            "description": "CVSS 5.6"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-MINIMIST-559764",
+        "title": "Prototype Pollution",
+        "severity": "medium",
+        "url": "https://snyk.io/vuln/SNYK-JS-MINIMIST-559764",
+        "identifiers": {
+          "CVE": ["CVE-2020-7598"],
+          "CWE": ["CWE-400"],
+          "NSP": [1179],
+          "GHSA": ["GHSA-vh95-rmgr-6w4m"]
+        },
+        "credit": ["Snyk Security Team"],
+        "exploitMaturity": "proof-of-concept",
+        "semver": {
+          "vulnerable": ["<0.2.1", ">=1.0.0 <1.2.3"]
+        },
+        "publicationTime": "2020-03-11T08:22:19Z",
+        "disclosureTime": "2020-03-10T08:22:24Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "cvssScore": 5.6,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-BL-608877",
+      "issueType": "vuln",
+      "pkgName": "bl",
+      "pkgVersions": ["1.2.2"],
+      "priorityScore": 385,
+      "priority": {
+        "score": 385,
+        "factors": [
+          {
+            "name": "cvssScore",
+            "description": "CVSS 7.7"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-BL-608877",
+        "title": "Remote Memory Exposure",
+        "severity": "high",
+        "url": "https://snyk.io/vuln/SNYK-JS-BL-608877",
+        "identifiers": {
+          "CVE": ["CVE-2020-8244"],
+          "CWE": ["CWE-9"],
+          "NSP": [1555],
+          "GHSA": ["GHSA-pp7h-53gx-mx7r"]
+        },
+        "credit": ["chalker"],
+        "exploitMaturity": "no-known-exploit",
+        "semver": {
+          "vulnerable": [
+            ">=2.2.0 <2.2.1",
+            ">=3.0.0 <3.0.1",
+            ">=4.0.0 <4.0.3",
+            "<1.2.3"
+          ]
+        },
+        "publicationTime": "2020-08-28T12:18:48Z",
+        "disclosureTime": "2020-08-27T15:16:42Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:L/A:L",
+        "cvssScore": 7.7,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-EJS-1049328",
+      "issueType": "vuln",
+      "pkgName": "ejs",
+      "pkgVersions": ["0.8.8", "2.5.5"],
+      "priorityScore": 384,
+      "priority": {
+        "score": 384,
+        "factors": [
+          {
+            "name": "exploitMaturity",
+            "description": "Proof of Concept exploit"
+          },
+          {
+            "name": "isFresh",
+            "description": "Recently disclosed"
+          },
+          {
+            "name": "cvssScore",
+            "description": "CVSS 4.1"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-EJS-1049328",
+        "title": "Arbitrary Code Injection",
+        "severity": "medium",
+        "url": "https://snyk.io/vuln/SNYK-JS-EJS-1049328",
+        "identifiers": {
+          "CVE": [],
+          "CWE": ["CWE-94"]
+        },
+        "credit": ["fangzequn"],
+        "exploitMaturity": "proof-of-concept",
+        "semver": {
+          "vulnerable": ["*"]
+        },
+        "publicationTime": "2021-01-20T16:41:56.788999Z",
+        "disclosureTime": "2020-12-09T11:56:29Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:L/I:L/A:L/E:P/RL:U/RC:C",
+        "cvssScore": 4.1,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": false,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "SNYK-JS-ACORN-559469",
+      "issueType": "vuln",
+      "pkgName": "acorn",
+      "pkgVersions": ["5.7.3"],
+      "priorityScore": 375,
+      "priority": {
+        "score": 375,
+        "factors": [
+          {
+            "name": "cvssScore",
+            "description": "CVSS 7.5"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "SNYK-JS-ACORN-559469",
+        "title": "Regular Expression Denial of Service (ReDoS)",
+        "severity": "high",
+        "url": "https://snyk.io/vuln/SNYK-JS-ACORN-559469",
+        "identifiers": {
+          "CVE": [],
+          "CWE": ["CWE-400"],
+          "NSP": [1488],
+          "GHSA": ["GHSA-6chw-6frg-f759"]
+        },
+        "credit": ["Peter van der Zee"],
+        "exploitMaturity": "no-known-exploit",
+        "semver": {
+          "vulnerable": [">=5.5.0 <5.7.4", ">=6.0.0 <6.4.1", ">=7.0.0 <7.1.1"]
+        },
+        "publicationTime": "2020-03-07T00:19:23Z",
+        "disclosureTime": "2020-03-02T19:21:25Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "cvssScore": 7.5,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": true,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "npm:ejs:20161130-1",
+      "issueType": "vuln",
+      "pkgName": "ejs",
+      "pkgVersions": ["0.8.8"],
+      "priorityScore": 295,
+      "priority": {
+        "score": 295,
+        "factors": [
+          {
+            "name": "cvssScore",
+            "description": "CVSS 5.9"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "npm:ejs:20161130-1",
+        "title": "Denial of Service (DoS)",
+        "severity": "medium",
+        "url": "https://snyk.io/vuln/npm:ejs:20161130-1",
+        "identifiers": {
+          "CVE": ["CVE-2017-1000189"],
+          "CWE": ["CWE-400"],
+          "ALTERNATIVE": ["SNYK-JS-EJS-10226"]
+        },
+        "credit": ["Snyk Security Research Team"],
+        "exploitMaturity": "no-known-exploit",
+        "semver": {
+          "vulnerable": ["<2.5.5"]
+        },
+        "publicationTime": "2016-12-06T15:00:00Z",
+        "disclosureTime": "2016-11-27T22:00:00Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "cvssScore": 5.9,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": false,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    },
+    {
+      "id": "npm:ejs:20161130",
+      "issueType": "vuln",
+      "pkgName": "ejs",
+      "pkgVersions": ["0.8.8"],
+      "priorityScore": 295,
+      "priority": {
+        "score": 295,
+        "factors": [
+          {
+            "name": "cvssScore",
+            "description": "CVSS 5.9"
+          }
+        ]
+      },
+      "issueData": {
+        "id": "npm:ejs:20161130",
+        "title": "Cross-site Scripting (XSS)",
+        "severity": "medium",
+        "url": "https://snyk.io/vuln/npm:ejs:20161130",
+        "identifiers": {
+          "CVE": ["CVE-2017-1000188"],
+          "CWE": ["CWE-79"],
+          "ALTERNATIVE": ["SNYK-JS-EJS-10225"]
+        },
+        "credit": ["Snyk Security Research Team"],
+        "exploitMaturity": "no-known-exploit",
+        "semver": {
+          "vulnerable": ["<2.5.5"]
+        },
+        "publicationTime": "2016-12-06T15:00:00Z",
+        "disclosureTime": "2016-11-27T22:00:00Z",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+        "cvssScore": 5.9,
+        "language": "js",
+        "patches": [],
+        "nearestFixedInVersion": ""
+      },
+      "isPatched": false,
+      "isIgnored": false,
+      "fixInfo": {
+        "isUpgradable": false,
+        "isPinnable": false,
+        "isPatchable": false,
+        "isPartiallyFixable": false,
+        "nearestFixedInVersion": ""
+      }
+    }
+  ]
+}

--- a/test/fixtures/abstraction/org/aggregatedIssuesWithVulnPaths-goof.json
+++ b/test/fixtures/abstraction/org/aggregatedIssuesWithVulnPaths-goof.json
@@ -1,0 +1,1092 @@
+{
+    "issues": [
+      {
+        "id": "SNYK-JS-EXPRESSFILEUPLOAD-473997",
+        "issueType": "vuln",
+        "pkgName": "express-fileupload",
+        "pkgVersions": [{ "0.0.5": [["express-fileupload@0.0.5"]] }],
+        "priorityScore": 704,
+        "priority": {
+          "score": 704,
+          "factors": [
+            { "name": "isFixable", "description": "Has a fix available" },
+            { "name": "cvssScore", "description": "CVSS 9.8" }
+          ]
+        },
+        "issueData": {
+          "id": "SNYK-JS-EXPRESSFILEUPLOAD-473997",
+          "title": "Denial of Service (DoS)",
+          "severity": "high",
+          "url": "https://snyk.io/vuln/SNYK-JS-EXPRESSFILEUPLOAD-473997",
+          "identifiers": {
+            "CVE": [],
+            "CWE": ["CWE-79"],
+            "NSP": [1216],
+            "GHSA": ["GHSA-q3w9-g74q-vp5f"]
+          },
+          "credit": ["Roman Burunkov"],
+          "exploitMaturity": "no-known-exploit",
+          "semver": { "vulnerable": ["<1.1.6-alpha.6"] },
+          "publicationTime": "2019-10-22T15:08:40Z",
+          "disclosureTime": "2019-10-18T11:17:09Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 9.8,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": true,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-EXPRESSFILEUPLOAD-595969",
+        "issueType": "vuln",
+        "pkgName": "express-fileupload",
+        "pkgVersions": [{ "0.0.5": [["express-fileupload@0.0.5"]] }],
+        "priorityScore": 696,
+        "priority": {
+          "score": 696,
+          "factors": [
+            {
+              "name": "exploitMaturity",
+              "description": "Proof of Concept exploit"
+            },
+            { "name": "isFixable", "description": "Has a fix available" },
+            { "name": "cvssScore", "description": "CVSS 7.5" }
+          ]
+        },
+        "issueData": {
+          "id": "SNYK-JS-EXPRESSFILEUPLOAD-595969",
+          "title": "Prototype Pollution",
+          "severity": "high",
+          "url": "https://snyk.io/vuln/SNYK-JS-EXPRESSFILEUPLOAD-595969",
+          "identifiers": {
+            "CVE": ["CVE-2020-7699"],
+            "CWE": ["CWE-400"],
+            "GHSA": ["GHSA-9wcg-jrwf-8gg7"]
+          },
+          "credit": ["po6ix"],
+          "exploitMaturity": "proof-of-concept",
+          "semver": { "vulnerable": ["<1.1.10"] },
+          "publicationTime": "2020-07-30T15:28:18Z",
+          "disclosureTime": "2020-07-29T15:08:59Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+          "cvssScore": 7.5,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": true,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-TREEKILL-536781",
+        "issueType": "vuln",
+        "pkgName": "tree-kill",
+        "pkgVersions": [
+          {
+            "1.2.1": [
+              ["snyk@1.228.3", "snyk-sbt-plugin@2.8.0", "tree-kill@1.2.1"]
+            ]
+          }
+        ],
+        "priorityScore": 671,
+        "priority": {
+          "score": 671,
+          "factors": [
+            {
+              "name": "exploitMaturity",
+              "description": "Proof of Concept exploit"
+            },
+            { "name": "isFixable", "description": "Has a fix available" },
+            { "name": "cvssScore", "description": "CVSS 7" }
+          ]
+        },
+        "issueData": {
+          "id": "SNYK-JS-TREEKILL-536781",
+          "title": "Command Injection",
+          "severity": "high",
+          "url": "https://snyk.io/vuln/SNYK-JS-TREEKILL-536781",
+          "identifiers": {
+            "CVE": ["CVE-2019-15598", "CVE-2019-15599"],
+            "CWE": ["CWE-78"],
+            "NSP": [1432, 1433]
+          },
+          "credit": ["mik317"],
+          "exploitMaturity": "proof-of-concept",
+          "semver": { "vulnerable": ["<1.2.2"] },
+          "publicationTime": "2019-12-05T10:51:40Z",
+          "disclosureTime": "2019-12-04T19:54:11Z",
+          "CVSSv3": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H/E:P/RL:U/RC:C",
+          "cvssScore": 7,
+          "language": "js",
+          "patches": [
+            {
+              "id": "patch:SNYK-JS-TREEKILL-536781:0",
+              "urls": [
+                "https://snyk-patches.s3.amazonaws.com/npm/tree-kill/20191210/tree-kill_0_0_20191210_e5d66d1fbd4b392294512d4644ac22bdc888573c.patch"
+              ],
+              "version": ">=1.0.0",
+              "comments": [],
+              "modificationTime": "2019-12-11T11:57:51.268946Z"
+            }
+          ],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": true,
+          "isPartiallyFixable": true,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-LODASH-567746",
+        "issueType": "vuln",
+        "pkgName": "lodash",
+        "pkgVersions": [
+          {
+            "4.17.15": [
+              ["snyk@1.228.3", "lodash@4.17.15"],
+              ["snyk@1.228.3", "@snyk/dep-graph@1.12.0", "lodash@4.17.15"],
+              ["snyk@1.228.3", "inquirer@6.5.2", "lodash@4.17.15"],
+              ["snyk@1.228.3", "snyk-config@2.2.3", "lodash@4.17.15"],
+              ["snyk@1.228.3", "snyk-mvn-plugin@2.4.0", "lodash@4.17.15"],
+              [
+                "snyk@1.228.3",
+                "snyk-nodejs-lockfile-parser@1.16.0",
+                "lodash@4.17.15"
+              ],
+              ["snyk@1.228.3", "snyk-nuget-plugin@1.12.1", "lodash@4.17.15"],
+              [
+                "snyk@1.228.3",
+                "@snyk/dep-graph@1.12.0",
+                "graphlib@2.1.7",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-go-plugin@1.11.0",
+                "graphlib@2.1.7",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-nodejs-lockfile-parser@1.16.0",
+                "graphlib@2.1.7",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-nuget-plugin@1.12.1",
+                "dotnet-deps-parser@4.5.0",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-php-plugin@1.6.4",
+                "@snyk/composer-lockfile-parser@1.0.3",
+                "lodash@4.17.15"
+              ]
+            ]
+          }
+        ],
+        "priorityScore": 636,
+        "priority": {
+          "score": 636,
+          "factors": [
+            {
+              "name": "exploitMaturity",
+              "description": "Proof of Concept exploit"
+            },
+            { "name": "isFixable", "description": "Has a fix available" },
+            { "name": "cvssScore", "description": "CVSS 6.3" }
+          ]
+        },
+        "issueData": {
+          "id": "SNYK-JS-LODASH-567746",
+          "title": "Prototype Pollution",
+          "severity": "medium",
+          "url": "https://snyk.io/vuln/SNYK-JS-LODASH-567746",
+          "identifiers": {
+            "CVE": ["CVE-2020-8203"],
+            "CWE": ["CWE-400"],
+            "NSP": [1523],
+            "GHSA": ["GHSA-p6mc-m468-83gw"]
+          },
+          "credit": ["posix"],
+          "exploitMaturity": "proof-of-concept",
+          "semver": { "vulnerable": ["<4.17.16"] },
+          "publicationTime": "2020-04-28T14:59:14Z",
+          "disclosureTime": "2020-04-27T22:14:18Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:U/RC:C",
+          "cvssScore": 6.3,
+          "language": "js",
+          "patches": [
+            {
+              "id": "patch:SNYK-JS-LODASH-567746:0",
+              "urls": [
+                "https://snyk-patches.s3.amazonaws.com/npm/lodash/20200430/lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+              ],
+              "version": ">=4.14.2",
+              "comments": [],
+              "modificationTime": "2020-04-30T14:28:46.729327Z"
+            }
+          ],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": true,
+          "isPartiallyFixable": true,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-HTTPSPROXYAGENT-469131",
+        "issueType": "vuln",
+        "pkgName": "https-proxy-agent",
+        "pkgVersions": [
+          {
+            "2.2.2": [
+              ["snyk@1.228.3", "proxy-agent@3.1.0", "https-proxy-agent@2.2.2"],
+              [
+                "snyk@1.228.3",
+                "proxy-agent@3.1.0",
+                "pac-proxy-agent@3.0.0",
+                "https-proxy-agent@2.2.2"
+              ]
+            ]
+          }
+        ],
+        "priorityScore": 626,
+        "priority": {
+          "score": 626,
+          "factors": [
+            {
+              "name": "exploitMaturity",
+              "description": "Proof of Concept exploit"
+            },
+            { "name": "isFixable", "description": "Has a fix available" },
+            { "name": "cvssScore", "description": "CVSS 6.1" }
+          ]
+        },
+        "issueData": {
+          "id": "SNYK-JS-HTTPSPROXYAGENT-469131",
+          "title": "Man-in-the-Middle (MitM)",
+          "severity": "medium",
+          "url": "https://snyk.io/vuln/SNYK-JS-HTTPSPROXYAGENT-469131",
+          "identifiers": { "CVE": [], "CWE": ["CWE-300"], "NSP": [1184] },
+          "credit": ["Kris Adler"],
+          "exploitMaturity": "proof-of-concept",
+          "semver": { "vulnerable": ["<2.2.3"] },
+          "publicationTime": "2019-10-02T08:08:11Z",
+          "disclosureTime": "2019-09-25T08:21:57Z",
+          "CVSSv3": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N/E:P/RL:U/RC:C",
+          "cvssScore": 6.1,
+          "language": "js",
+          "patches": [
+            {
+              "id": "patch:SNYK-JS-HTTPSPROXYAGENT-469131:0",
+              "urls": [
+                "https://snyk-patches.s3.amazonaws.com/npm/https-proxy-agent/20190929/https-proxy-agent_0_0_20190929.patch"
+              ],
+              "version": "=2.2.1",
+              "comments": [],
+              "modificationTime": "2019-12-03T11:40:45.721480Z"
+            },
+            {
+              "id": "patch:SNYK-JS-HTTPSPROXYAGENT-469131:1",
+              "urls": [
+                "https://snyk-patches.s3.amazonaws.com/npm/https-proxy-agent/20190929/https-proxy-agent_0_1_20190929.patch"
+              ],
+              "version": "=2.2.2",
+              "comments": [],
+              "modificationTime": "2019-12-03T11:40:45.723464Z"
+            }
+          ],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": true,
+          "isPartiallyFixable": true,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "snyk:lic:npm:goof:GPL-2.0",
+        "issueType": "license",
+        "pkgName": "goof",
+        "pkgVersions": [{ "0.0.3": [[]] }],
+        "priorityScore": 625,
+        "priority": {
+          "score": 625,
+          "factors": [
+            { "name": "isFresh", "description": "Recently disclosed" },
+            { "name": "severity", "description": "High severity" }
+          ]
+        },
+        "issueData": {
+          "id": "snyk:lic:npm:goof:GPL-2.0",
+          "title": "GPL-2.0 license",
+          "severity": "high",
+          "url": "https://snyk.io/vuln/snyk:lic:npm:goof:GPL-2.0",
+          "exploitMaturity": "no-data",
+          "semver": { "vulnerable": [">=0"] },
+          "publicationTime": "2021-02-01T14:58:40.027Z",
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": false,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-LODASH-590103",
+        "issueType": "vuln",
+        "pkgName": "lodash",
+        "pkgVersions": [
+          {
+            "4.17.15": [
+              ["snyk@1.228.3", "lodash@4.17.15"],
+              ["snyk@1.228.3", "@snyk/dep-graph@1.12.0", "lodash@4.17.15"],
+              ["snyk@1.228.3", "inquirer@6.5.2", "lodash@4.17.15"],
+              ["snyk@1.228.3", "snyk-config@2.2.3", "lodash@4.17.15"],
+              ["snyk@1.228.3", "snyk-mvn-plugin@2.4.0", "lodash@4.17.15"],
+              [
+                "snyk@1.228.3",
+                "snyk-nodejs-lockfile-parser@1.16.0",
+                "lodash@4.17.15"
+              ],
+              ["snyk@1.228.3", "snyk-nuget-plugin@1.12.1", "lodash@4.17.15"],
+              [
+                "snyk@1.228.3",
+                "@snyk/dep-graph@1.12.0",
+                "graphlib@2.1.7",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-go-plugin@1.11.0",
+                "graphlib@2.1.7",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-nodejs-lockfile-parser@1.16.0",
+                "graphlib@2.1.7",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-nuget-plugin@1.12.1",
+                "dotnet-deps-parser@4.5.0",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-php-plugin@1.6.4",
+                "@snyk/composer-lockfile-parser@1.0.3",
+                "lodash@4.17.15"
+              ]
+            ]
+          }
+        ],
+        "priorityScore": 490,
+        "priority": {
+          "score": 490,
+          "factors": [{ "name": "cvssScore", "description": "CVSS 9.8" }]
+        },
+        "issueData": {
+          "id": "SNYK-JS-LODASH-590103",
+          "title": "Prototype Pollution",
+          "severity": "high",
+          "url": "https://snyk.io/vuln/SNYK-JS-LODASH-590103",
+          "identifiers": { "CVE": [], "CWE": ["CWE-400"] },
+          "credit": ["reeser"],
+          "exploitMaturity": "no-known-exploit",
+          "semver": { "vulnerable": ["<4.17.20"] },
+          "publicationTime": "2020-08-16T13:09:06Z",
+          "disclosureTime": "2020-07-24T12:00:52Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 9.8,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-Y18N-1021887",
+        "issueType": "vuln",
+        "pkgName": "y18n",
+        "pkgVersions": [
+          {
+            "3.2.1": [
+              [
+                "snyk@1.228.3",
+                "snyk-config@2.2.3",
+                "nconf@0.10.0",
+                "yargs@3.32.0",
+                "y18n@3.2.1"
+              ]
+            ]
+          }
+        ],
+        "priorityScore": 472,
+        "priority": {
+          "score": 472,
+          "factors": [
+            {
+              "name": "exploitMaturity",
+              "description": "Proof of Concept exploit"
+            },
+            { "name": "cvssScore", "description": "CVSS 7.3" }
+          ]
+        },
+        "issueData": {
+          "id": "SNYK-JS-Y18N-1021887",
+          "title": "Prototype Pollution",
+          "severity": "high",
+          "url": "https://snyk.io/vuln/SNYK-JS-Y18N-1021887",
+          "identifiers": { "CVE": ["CVE-2020-7774"], "CWE": ["CWE-400"] },
+          "credit": ["po6ix"],
+          "exploitMaturity": "proof-of-concept",
+          "semver": {
+            "vulnerable": ["<3.2.2", ">=4.0.0 <4.0.1", ">=5.0.0 <5.0.5"]
+          },
+          "publicationTime": "2020-11-10T15:27:28Z",
+          "disclosureTime": "2020-10-25T14:24:22Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "cvssScore": 7.3,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-LODASH-608086",
+        "issueType": "vuln",
+        "pkgName": "lodash",
+        "pkgVersions": [
+          {
+            "4.17.15": [
+              ["snyk@1.228.3", "lodash@4.17.15"],
+              ["snyk@1.228.3", "@snyk/dep-graph@1.12.0", "lodash@4.17.15"],
+              ["snyk@1.228.3", "inquirer@6.5.2", "lodash@4.17.15"],
+              ["snyk@1.228.3", "snyk-config@2.2.3", "lodash@4.17.15"],
+              ["snyk@1.228.3", "snyk-mvn-plugin@2.4.0", "lodash@4.17.15"],
+              [
+                "snyk@1.228.3",
+                "snyk-nodejs-lockfile-parser@1.16.0",
+                "lodash@4.17.15"
+              ],
+              ["snyk@1.228.3", "snyk-nuget-plugin@1.12.1", "lodash@4.17.15"],
+              [
+                "snyk@1.228.3",
+                "@snyk/dep-graph@1.12.0",
+                "graphlib@2.1.7",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-go-plugin@1.11.0",
+                "graphlib@2.1.7",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-nodejs-lockfile-parser@1.16.0",
+                "graphlib@2.1.7",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-nuget-plugin@1.12.1",
+                "dotnet-deps-parser@4.5.0",
+                "lodash@4.17.15"
+              ],
+              [
+                "snyk@1.228.3",
+                "snyk-php-plugin@1.6.4",
+                "@snyk/composer-lockfile-parser@1.0.3",
+                "lodash@4.17.15"
+              ]
+            ]
+          }
+        ],
+        "priorityScore": 472,
+        "priority": {
+          "score": 472,
+          "factors": [
+            {
+              "name": "exploitMaturity",
+              "description": "Proof of Concept exploit"
+            },
+            { "name": "cvssScore", "description": "CVSS 7.3" }
+          ]
+        },
+        "issueData": {
+          "id": "SNYK-JS-LODASH-608086",
+          "title": "Prototype Pollution",
+          "severity": "high",
+          "url": "https://snyk.io/vuln/SNYK-JS-LODASH-608086",
+          "identifiers": { "CVE": [], "CWE": ["CWE-400"] },
+          "credit": ["awarau"],
+          "exploitMaturity": "proof-of-concept",
+          "semver": { "vulnerable": ["<4.17.17"] },
+          "publicationTime": "2020-08-21T12:53:03Z",
+          "disclosureTime": "2020-08-21T10:34:29Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "cvssScore": 7.3,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-INI-1048974",
+        "issueType": "vuln",
+        "pkgName": "ini",
+        "pkgVersions": [
+          {
+            "1.3.5": [
+              ["npmconf@2.1.3", "ini@1.3.5"],
+              ["npmconf@2.1.3", "config-chain@1.1.12", "ini@1.3.5"],
+              ["snyk@1.228.3", "snyk-config@2.2.3", "nconf@0.10.0", "ini@1.3.5"],
+              [
+                "snyk@1.228.3",
+                "update-notifier@2.5.0",
+                "is-installed-globally@0.1.0",
+                "global-dirs@0.1.1",
+                "ini@1.3.5"
+              ],
+              [
+                "snyk@1.228.3",
+                "update-notifier@2.5.0",
+                "latest-version@3.1.0",
+                "package-json@4.0.1",
+                "registry-auth-token@3.4.0",
+                "rc@1.2.8",
+                "ini@1.3.5"
+              ],
+              [
+                "snyk@1.228.3",
+                "update-notifier@2.5.0",
+                "latest-version@3.1.0",
+                "package-json@4.0.1",
+                "registry-url@3.1.0",
+                "rc@1.2.8",
+                "ini@1.3.5"
+              ]
+            ]
+          }
+        ],
+        "priorityScore": 472,
+        "priority": {
+          "score": 472,
+          "factors": [
+            {
+              "name": "exploitMaturity",
+              "description": "Proof of Concept exploit"
+            },
+            { "name": "cvssScore", "description": "CVSS 7.3" }
+          ]
+        },
+        "issueData": {
+          "id": "SNYK-JS-INI-1048974",
+          "title": "Prototype Pollution",
+          "severity": "high",
+          "url": "https://snyk.io/vuln/SNYK-JS-INI-1048974",
+          "identifiers": {
+            "CVE": ["CVE-2020-7788"],
+            "CWE": ["CWE-400"],
+            "GHSA": ["GHSA-qqgx-2p2h-9c37"]
+          },
+          "credit": [
+            "Eugene Lim",
+            "Government Technology Agency Cyber Security Group"
+          ],
+          "exploitMaturity": "proof-of-concept",
+          "semver": { "vulnerable": ["<1.3.6"] },
+          "publicationTime": "2020-12-10T18:08:38Z",
+          "disclosureTime": "2020-12-08T13:02:04Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "cvssScore": 7.3,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-DOTPROP-543489",
+        "issueType": "vuln",
+        "pkgName": "dot-prop",
+        "pkgVersions": [
+          {
+            "4.2.0": [
+              ["snyk@1.228.3", "configstore@3.1.2", "dot-prop@4.2.0"],
+              [
+                "snyk@1.228.3",
+                "update-notifier@2.5.0",
+                "configstore@3.1.2",
+                "dot-prop@4.2.0"
+              ]
+            ]
+          }
+        ],
+        "priorityScore": 422,
+        "priority": {
+          "score": 422,
+          "factors": [
+            {
+              "name": "exploitMaturity",
+              "description": "Proof of Concept exploit"
+            },
+            { "name": "cvssScore", "description": "CVSS 6.3" }
+          ]
+        },
+        "issueData": {
+          "id": "SNYK-JS-DOTPROP-543489",
+          "title": "Prototype Pollution",
+          "severity": "medium",
+          "url": "https://snyk.io/vuln/SNYK-JS-DOTPROP-543489",
+          "identifiers": { "CVE": ["CVE-2020-8116"], "CWE": ["CWE-400"] },
+          "credit": ["aaron_costello"],
+          "exploitMaturity": "proof-of-concept",
+          "semver": { "vulnerable": [">1.0.1 <4.2.1", ">=5.0.0 <5.1.1"] },
+          "publicationTime": "2020-01-28T16:23:39Z",
+          "disclosureTime": "2020-01-28T10:17:51Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "cvssScore": 6.3,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "npm:ejs:20161128",
+        "issueType": "vuln",
+        "pkgName": "ejs",
+        "pkgVersions": [{ "0.8.8": [["ejs-locals@1.0.2", "ejs@0.8.8"]] }],
+        "priorityScore": 405,
+        "priority": {
+          "score": 405,
+          "factors": [{ "name": "cvssScore", "description": "CVSS 8.1" }]
+        },
+        "issueData": {
+          "id": "npm:ejs:20161128",
+          "title": "Arbitrary Code Execution",
+          "severity": "high",
+          "url": "https://snyk.io/vuln/npm:ejs:20161128",
+          "identifiers": {
+            "CVE": ["CVE-2017-1000228"],
+            "CWE": ["CWE-94"],
+            "ALTERNATIVE": ["SNYK-JS-EJS-10218"]
+          },
+          "credit": ["Snyk Security Research Team"],
+          "exploitMaturity": "no-known-exploit",
+          "semver": { "vulnerable": ["<2.5.3"] },
+          "publicationTime": "2016-11-28T18:44:12Z",
+          "disclosureTime": "2016-11-27T22:00:00Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 8.1,
+          "language": "js",
+          "patches": [
+            {
+              "id": "patch:npm:ejs:20161128:0",
+              "urls": [
+                "https://snyk-patches.s3.amazonaws.com/npm/ejs/20161128/ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+              ],
+              "version": "<2.5.3 >=2.2.4",
+              "comments": [],
+              "modificationTime": "2019-12-03T11:40:45.851976Z"
+            }
+          ],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": false,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-MINIMIST-559764",
+        "issueType": "vuln",
+        "pkgName": "minimist",
+        "pkgVersions": [
+          {
+            "1.2.0": [
+              [
+                "snyk@1.228.3",
+                "update-notifier@2.5.0",
+                "latest-version@3.1.0",
+                "package-json@4.0.1",
+                "registry-auth-token@3.4.0",
+                "rc@1.2.8",
+                "minimist@1.2.0"
+              ],
+              [
+                "snyk@1.228.3",
+                "update-notifier@2.5.0",
+                "latest-version@3.1.0",
+                "package-json@4.0.1",
+                "registry-url@3.1.0",
+                "rc@1.2.8",
+                "minimist@1.2.0"
+              ]
+            ]
+          },
+          { "0.0.8": [["npmconf@2.1.3", "mkdirp@0.5.1", "minimist@0.0.8"]] },
+          { "0.0.10": [["tslint@5.1.0", "optimist@0.6.1", "minimist@0.0.10"]] }
+        ],
+        "priorityScore": 387,
+        "priority": {
+          "score": 387,
+          "factors": [
+            {
+              "name": "exploitMaturity",
+              "description": "Proof of Concept exploit"
+            },
+            { "name": "cvssScore", "description": "CVSS 5.6" }
+          ]
+        },
+        "issueData": {
+          "id": "SNYK-JS-MINIMIST-559764",
+          "title": "Prototype Pollution",
+          "severity": "medium",
+          "url": "https://snyk.io/vuln/SNYK-JS-MINIMIST-559764",
+          "identifiers": {
+            "CVE": ["CVE-2020-7598"],
+            "CWE": ["CWE-400"],
+            "NSP": [1179],
+            "GHSA": ["GHSA-vh95-rmgr-6w4m"]
+          },
+          "credit": ["Snyk Security Team"],
+          "exploitMaturity": "proof-of-concept",
+          "semver": { "vulnerable": ["<0.2.1", ">=1.0.0 <1.2.3"] },
+          "publicationTime": "2020-03-11T08:22:19Z",
+          "disclosureTime": "2020-03-10T08:22:24Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "cvssScore": 5.6,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-BL-608877",
+        "issueType": "vuln",
+        "pkgName": "bl",
+        "pkgVersions": [{ "1.2.2": [["st@1.2.2", "bl@1.2.2"]] }],
+        "priorityScore": 385,
+        "priority": {
+          "score": 385,
+          "factors": [{ "name": "cvssScore", "description": "CVSS 7.7" }]
+        },
+        "issueData": {
+          "id": "SNYK-JS-BL-608877",
+          "title": "Remote Memory Exposure",
+          "severity": "high",
+          "url": "https://snyk.io/vuln/SNYK-JS-BL-608877",
+          "identifiers": {
+            "CVE": ["CVE-2020-8244"],
+            "CWE": ["CWE-9"],
+            "NSP": [1555],
+            "GHSA": ["GHSA-pp7h-53gx-mx7r"]
+          },
+          "credit": ["chalker"],
+          "exploitMaturity": "no-known-exploit",
+          "semver": {
+            "vulnerable": [
+              ">=2.2.0 <2.2.1",
+              ">=3.0.0 <3.0.1",
+              ">=4.0.0 <4.0.3",
+              "<1.2.3"
+            ]
+          },
+          "publicationTime": "2020-08-28T12:18:48Z",
+          "disclosureTime": "2020-08-27T15:16:42Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:L/A:L",
+          "cvssScore": 7.7,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-EJS-1049328",
+        "issueType": "vuln",
+        "pkgName": "ejs",
+        "pkgVersions": [
+          { "0.8.8": [["ejs-locals@1.0.2", "ejs@0.8.8"]] },
+          { "2.5.5": [["ejs@2.5.5"]] }
+        ],
+        "priorityScore": 384,
+        "priority": {
+          "score": 384,
+          "factors": [
+            {
+              "name": "exploitMaturity",
+              "description": "Proof of Concept exploit"
+            },
+            { "name": "isFresh", "description": "Recently disclosed" },
+            { "name": "cvssScore", "description": "CVSS 4.1" }
+          ]
+        },
+        "issueData": {
+          "id": "SNYK-JS-EJS-1049328",
+          "title": "Arbitrary Code Injection",
+          "severity": "medium",
+          "url": "https://snyk.io/vuln/SNYK-JS-EJS-1049328",
+          "identifiers": { "CVE": [], "CWE": ["CWE-94"] },
+          "credit": ["fangzequn"],
+          "exploitMaturity": "proof-of-concept",
+          "semver": { "vulnerable": ["*"] },
+          "publicationTime": "2021-01-20T16:41:56.788999Z",
+          "disclosureTime": "2020-12-09T11:56:29Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:L/I:L/A:L/E:P/RL:U/RC:C",
+          "cvssScore": 4.1,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": false,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "SNYK-JS-ACORN-559469",
+        "issueType": "vuln",
+        "pkgName": "acorn",
+        "pkgVersions": [
+          { "5.7.3": [["@snyk/nodejs-runtime-agent@1.14.0", "acorn@5.7.3"]] }
+        ],
+        "priorityScore": 375,
+        "priority": {
+          "score": 375,
+          "factors": [{ "name": "cvssScore", "description": "CVSS 7.5" }]
+        },
+        "issueData": {
+          "id": "SNYK-JS-ACORN-559469",
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "severity": "high",
+          "url": "https://snyk.io/vuln/SNYK-JS-ACORN-559469",
+          "identifiers": {
+            "CVE": [],
+            "CWE": ["CWE-400"],
+            "NSP": [1488],
+            "GHSA": ["GHSA-6chw-6frg-f759"]
+          },
+          "credit": ["Peter van der Zee"],
+          "exploitMaturity": "no-known-exploit",
+          "semver": {
+            "vulnerable": [">=5.5.0 <5.7.4", ">=6.0.0 <6.4.1", ">=7.0.0 <7.1.1"]
+          },
+          "publicationTime": "2020-03-07T00:19:23Z",
+          "disclosureTime": "2020-03-02T19:21:25Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cvssScore": 7.5,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": true,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "npm:ejs:20161130-1",
+        "issueType": "vuln",
+        "pkgName": "ejs",
+        "pkgVersions": [{ "0.8.8": [["ejs-locals@1.0.2", "ejs@0.8.8"]] }],
+        "priorityScore": 295,
+        "priority": {
+          "score": 295,
+          "factors": [{ "name": "cvssScore", "description": "CVSS 5.9" }]
+        },
+        "issueData": {
+          "id": "npm:ejs:20161130-1",
+          "title": "Denial of Service (DoS)",
+          "severity": "medium",
+          "url": "https://snyk.io/vuln/npm:ejs:20161130-1",
+          "identifiers": {
+            "CVE": ["CVE-2017-1000189"],
+            "CWE": ["CWE-400"],
+            "ALTERNATIVE": ["SNYK-JS-EJS-10226"]
+          },
+          "credit": ["Snyk Security Research Team"],
+          "exploitMaturity": "no-known-exploit",
+          "semver": { "vulnerable": ["<2.5.5"] },
+          "publicationTime": "2016-12-06T15:00:00Z",
+          "disclosureTime": "2016-11-27T22:00:00Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cvssScore": 5.9,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": false,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      },
+      {
+        "id": "npm:ejs:20161130",
+        "issueType": "vuln",
+        "pkgName": "ejs",
+        "pkgVersions": [{ "0.8.8": [["ejs-locals@1.0.2", "ejs@0.8.8"]] }],
+        "priorityScore": 295,
+        "priority": {
+          "score": 295,
+          "factors": [{ "name": "cvssScore", "description": "CVSS 5.9" }]
+        },
+        "issueData": {
+          "id": "npm:ejs:20161130",
+          "title": "Cross-site Scripting (XSS)",
+          "severity": "medium",
+          "url": "https://snyk.io/vuln/npm:ejs:20161130",
+          "identifiers": {
+            "CVE": ["CVE-2017-1000188"],
+            "CWE": ["CWE-79"],
+            "ALTERNATIVE": ["SNYK-JS-EJS-10225"]
+          },
+          "credit": ["Snyk Security Research Team"],
+          "exploitMaturity": "no-known-exploit",
+          "semver": { "vulnerable": ["<2.5.5"] },
+          "publicationTime": "2016-12-06T15:00:00Z",
+          "disclosureTime": "2016-11-27T22:00:00Z",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+          "cvssScore": 5.9,
+          "language": "js",
+          "patches": [],
+          "nearestFixedInVersion": ""
+        },
+        "isPatched": false,
+        "isIgnored": false,
+        "fixInfo": {
+          "isUpgradable": false,
+          "isPinnable": false,
+          "isPatchable": false,
+          "isPartiallyFixable": false,
+          "nearestFixedInVersion": ""
+        }
+      }
+    ]
+  }
+  

--- a/test/fixtures/abstraction/org/depgraph-goof.json
+++ b/test/fixtures/abstraction/org/depgraph-goof.json
@@ -1,0 +1,9622 @@
+{
+  "depGraph": {
+    "schemaVersion": "1.2.0",
+    "pkgManager": {
+      "name": "npm"
+    },
+    "pkgs": [
+      {
+        "id": "goof@0.0.3",
+        "info": {
+          "name": "goof",
+          "version": "0.0.3"
+        }
+      },
+      {
+        "id": "acorn@5.7.3",
+        "info": {
+          "name": "acorn",
+          "version": "5.7.3"
+        }
+      },
+      {
+        "id": "ms@2.1.1",
+        "info": {
+          "name": "ms",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "debug@4.1.0",
+        "info": {
+          "name": "debug",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "id": "ms@2.0.0",
+        "info": {
+          "name": "ms",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "debug@2.6.9",
+        "info": {
+          "name": "debug",
+          "version": "2.6.9"
+        }
+      },
+      {
+        "id": "safer-buffer@2.1.2",
+        "info": {
+          "name": "safer-buffer",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "id": "iconv-lite@0.4.24",
+        "info": {
+          "name": "iconv-lite",
+          "version": "0.4.24"
+        }
+      },
+      {
+        "id": "sax@1.2.4",
+        "info": {
+          "name": "sax",
+          "version": "1.2.4"
+        }
+      },
+      {
+        "id": "needle@2.2.4",
+        "info": {
+          "name": "needle",
+          "version": "2.2.4"
+        }
+      },
+      {
+        "id": "semver@5.6.0",
+        "info": {
+          "name": "semver",
+          "version": "5.6.0"
+        }
+      },
+      {
+        "id": "@snyk/nodejs-runtime-agent@1.14.0",
+        "info": {
+          "name": "@snyk/nodejs-runtime-agent",
+          "version": "1.14.0"
+        }
+      },
+      {
+        "id": "sprintf-js@1.0.3",
+        "info": {
+          "name": "sprintf-js",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "id": "argparse@1.0.10",
+        "info": {
+          "name": "argparse",
+          "version": "1.0.10"
+        }
+      },
+      {
+        "id": "esprima@4.0.1",
+        "info": {
+          "name": "esprima",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "id": "js-yaml@3.13.1",
+        "info": {
+          "name": "js-yaml",
+          "version": "3.13.1"
+        }
+      },
+      {
+        "id": "ports@1.1.0",
+        "info": {
+          "name": "ports",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "underscore@1.9.1",
+        "info": {
+          "name": "underscore",
+          "version": "1.9.1"
+        }
+      },
+      {
+        "id": "cfenv@1.2.1",
+        "info": {
+          "name": "cfenv",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "id": "bluebird@3.5.3",
+        "info": {
+          "name": "bluebird",
+          "version": "3.5.3"
+        }
+      },
+      {
+        "id": "consolidate@0.14.5",
+        "info": {
+          "name": "consolidate",
+          "version": "0.14.5"
+        }
+      },
+      {
+        "id": "cookie@0.1.2",
+        "info": {
+          "name": "cookie",
+          "version": "0.1.2"
+        }
+      },
+      {
+        "id": "cookie-signature@1.0.5",
+        "info": {
+          "name": "cookie-signature",
+          "version": "1.0.5"
+        }
+      },
+      {
+        "id": "cookie-parser@1.3.3",
+        "info": {
+          "name": "cookie-parser",
+          "version": "1.3.3"
+        }
+      },
+      {
+        "id": "dustjs-helpers@1.5.0",
+        "info": {
+          "name": "dustjs-helpers",
+          "version": "1.5.0"
+        }
+      },
+      {
+        "id": "ejs@2.5.5",
+        "info": {
+          "name": "ejs",
+          "version": "2.5.5"
+        }
+      },
+      {
+        "id": "ejs@0.8.8",
+        "info": {
+          "name": "ejs",
+          "version": "0.8.8"
+        }
+      },
+      {
+        "id": "ejs-locals@1.0.2",
+        "info": {
+          "name": "ejs-locals",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "mime-db@1.40.0",
+        "info": {
+          "name": "mime-db",
+          "version": "1.40.0"
+        }
+      },
+      {
+        "id": "mime-types@2.1.24",
+        "info": {
+          "name": "mime-types",
+          "version": "2.1.24"
+        }
+      },
+      {
+        "id": "negotiator@0.6.2",
+        "info": {
+          "name": "negotiator",
+          "version": "0.6.2"
+        }
+      },
+      {
+        "id": "accepts@1.3.7",
+        "info": {
+          "name": "accepts",
+          "version": "1.3.7"
+        }
+      },
+      {
+        "id": "array-flatten@1.1.1",
+        "info": {
+          "name": "array-flatten",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "bytes@3.0.0",
+        "info": {
+          "name": "bytes",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "content-type@1.0.4",
+        "info": {
+          "name": "content-type",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "id": "depd@1.1.2",
+        "info": {
+          "name": "depd",
+          "version": "1.1.2"
+        }
+      },
+      {
+        "id": "inherits@2.0.3",
+        "info": {
+          "name": "inherits",
+          "version": "2.0.3"
+        }
+      },
+      {
+        "id": "setprototypeof@1.1.0",
+        "info": {
+          "name": "setprototypeof",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "statuses@1.5.0",
+        "info": {
+          "name": "statuses",
+          "version": "1.5.0"
+        }
+      },
+      {
+        "id": "http-errors@1.6.3",
+        "info": {
+          "name": "http-errors",
+          "version": "1.6.3"
+        }
+      },
+      {
+        "id": "iconv-lite@0.4.19",
+        "info": {
+          "name": "iconv-lite",
+          "version": "0.4.19"
+        }
+      },
+      {
+        "id": "ee-first@1.1.1",
+        "info": {
+          "name": "ee-first",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "on-finished@2.3.0",
+        "info": {
+          "name": "on-finished",
+          "version": "2.3.0"
+        }
+      },
+      {
+        "id": "qs@6.5.1",
+        "info": {
+          "name": "qs",
+          "version": "6.5.1"
+        }
+      },
+      {
+        "id": "depd@1.1.1",
+        "info": {
+          "name": "depd",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "setprototypeof@1.0.3",
+        "info": {
+          "name": "setprototypeof",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "id": "statuses@1.3.1",
+        "info": {
+          "name": "statuses",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "id": "http-errors@1.6.2",
+        "info": {
+          "name": "http-errors",
+          "version": "1.6.2"
+        }
+      },
+      {
+        "id": "unpipe@1.0.0",
+        "info": {
+          "name": "unpipe",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "raw-body@2.3.2",
+        "info": {
+          "name": "raw-body",
+          "version": "2.3.2"
+        }
+      },
+      {
+        "id": "media-typer@0.3.0",
+        "info": {
+          "name": "media-typer",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "id": "type-is@1.6.18",
+        "info": {
+          "name": "type-is",
+          "version": "1.6.18"
+        }
+      },
+      {
+        "id": "body-parser@1.18.2",
+        "info": {
+          "name": "body-parser",
+          "version": "1.18.2"
+        }
+      },
+      {
+        "id": "content-disposition@0.5.2",
+        "info": {
+          "name": "content-disposition",
+          "version": "0.5.2"
+        }
+      },
+      {
+        "id": "cookie@0.3.1",
+        "info": {
+          "name": "cookie",
+          "version": "0.3.1"
+        }
+      },
+      {
+        "id": "cookie-signature@1.0.6",
+        "info": {
+          "name": "cookie-signature",
+          "version": "1.0.6"
+        }
+      },
+      {
+        "id": "encodeurl@1.0.2",
+        "info": {
+          "name": "encodeurl",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "escape-html@1.0.3",
+        "info": {
+          "name": "escape-html",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "id": "etag@1.8.1",
+        "info": {
+          "name": "etag",
+          "version": "1.8.1"
+        }
+      },
+      {
+        "id": "parseurl@1.3.2",
+        "info": {
+          "name": "parseurl",
+          "version": "1.3.2"
+        }
+      },
+      {
+        "id": "finalhandler@1.1.0",
+        "info": {
+          "name": "finalhandler",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "fresh@0.5.2",
+        "info": {
+          "name": "fresh",
+          "version": "0.5.2"
+        }
+      },
+      {
+        "id": "merge-descriptors@1.0.1",
+        "info": {
+          "name": "merge-descriptors",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "methods@1.1.2",
+        "info": {
+          "name": "methods",
+          "version": "1.1.2"
+        }
+      },
+      {
+        "id": "path-to-regexp@0.1.7",
+        "info": {
+          "name": "path-to-regexp",
+          "version": "0.1.7"
+        }
+      },
+      {
+        "id": "forwarded@0.1.2",
+        "info": {
+          "name": "forwarded",
+          "version": "0.1.2"
+        }
+      },
+      {
+        "id": "ipaddr.js@1.9.0",
+        "info": {
+          "name": "ipaddr.js",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "id": "proxy-addr@2.0.5",
+        "info": {
+          "name": "proxy-addr",
+          "version": "2.0.5"
+        }
+      },
+      {
+        "id": "range-parser@1.2.1",
+        "info": {
+          "name": "range-parser",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "id": "safe-buffer@5.1.1",
+        "info": {
+          "name": "safe-buffer",
+          "version": "5.1.1"
+        }
+      },
+      {
+        "id": "destroy@1.0.4",
+        "info": {
+          "name": "destroy",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "id": "mime@1.4.1",
+        "info": {
+          "name": "mime",
+          "version": "1.4.1"
+        }
+      },
+      {
+        "id": "send@0.16.0",
+        "info": {
+          "name": "send",
+          "version": "0.16.0"
+        }
+      },
+      {
+        "id": "serve-static@1.13.0",
+        "info": {
+          "name": "serve-static",
+          "version": "1.13.0"
+        }
+      },
+      {
+        "id": "utils-merge@1.0.1",
+        "info": {
+          "name": "utils-merge",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "vary@1.1.2",
+        "info": {
+          "name": "vary",
+          "version": "1.1.2"
+        }
+      },
+      {
+        "id": "express@4.16.0",
+        "info": {
+          "name": "express",
+          "version": "4.16.0"
+        }
+      },
+      {
+        "id": "streamsearch@0.1.2",
+        "info": {
+          "name": "streamsearch",
+          "version": "0.1.2"
+        }
+      },
+      {
+        "id": "dicer@0.3.0",
+        "info": {
+          "name": "dicer",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "id": "busboy@0.3.1",
+        "info": {
+          "name": "busboy",
+          "version": "0.3.1"
+        }
+      },
+      {
+        "id": "connect-busboy@0.0.2",
+        "info": {
+          "name": "connect-busboy",
+          "version": "0.0.2"
+        }
+      },
+      {
+        "id": "graceful-fs@4.1.15",
+        "info": {
+          "name": "graceful-fs",
+          "version": "4.1.15"
+        }
+      },
+      {
+        "id": "jsonfile@2.4.0",
+        "info": {
+          "name": "jsonfile",
+          "version": "2.4.0"
+        }
+      },
+      {
+        "id": "fs.realpath@1.0.0",
+        "info": {
+          "name": "fs.realpath",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "wrappy@1.0.2",
+        "info": {
+          "name": "wrappy",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "once@1.4.0",
+        "info": {
+          "name": "once",
+          "version": "1.4.0"
+        }
+      },
+      {
+        "id": "inflight@1.0.6",
+        "info": {
+          "name": "inflight",
+          "version": "1.0.6"
+        }
+      },
+      {
+        "id": "balanced-match@1.0.0",
+        "info": {
+          "name": "balanced-match",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "concat-map@0.0.1",
+        "info": {
+          "name": "concat-map",
+          "version": "0.0.1"
+        }
+      },
+      {
+        "id": "brace-expansion@1.1.11",
+        "info": {
+          "name": "brace-expansion",
+          "version": "1.1.11"
+        }
+      },
+      {
+        "id": "minimatch@3.0.4",
+        "info": {
+          "name": "minimatch",
+          "version": "3.0.4"
+        }
+      },
+      {
+        "id": "path-is-absolute@1.0.1",
+        "info": {
+          "name": "path-is-absolute",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "glob@7.1.3",
+        "info": {
+          "name": "glob",
+          "version": "7.1.3"
+        }
+      },
+      {
+        "id": "rimraf@2.7.1",
+        "info": {
+          "name": "rimraf",
+          "version": "2.7.1"
+        }
+      },
+      {
+        "id": "fs-extra@0.22.1",
+        "info": {
+          "name": "fs-extra",
+          "version": "0.22.1"
+        }
+      },
+      {
+        "id": "streamifier@0.1.1",
+        "info": {
+          "name": "streamifier",
+          "version": "0.1.1"
+        }
+      },
+      {
+        "id": "express-fileupload@0.0.5",
+        "info": {
+          "name": "express-fileupload",
+          "version": "0.0.5"
+        }
+      },
+      {
+        "id": "ms@0.6.2",
+        "info": {
+          "name": "ms",
+          "version": "0.6.2"
+        }
+      },
+      {
+        "id": "humanize-ms@1.0.1",
+        "info": {
+          "name": "humanize-ms",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "debug@3.1.0",
+        "info": {
+          "name": "debug",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "method-override@3.0.0",
+        "info": {
+          "name": "method-override",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "moment@2.19.3",
+        "info": {
+          "name": "moment",
+          "version": "2.19.3"
+        }
+      },
+      {
+        "id": "safe-buffer@5.1.2",
+        "info": {
+          "name": "safe-buffer",
+          "version": "5.1.2"
+        }
+      },
+      {
+        "id": "basic-auth@2.0.1",
+        "info": {
+          "name": "basic-auth",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "on-headers@1.0.1",
+        "info": {
+          "name": "on-headers",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "morgan@1.9.1",
+        "info": {
+          "name": "morgan",
+          "version": "1.9.1"
+        }
+      },
+      {
+        "id": "ini@1.3.5",
+        "info": {
+          "name": "ini",
+          "version": "1.3.5"
+        }
+      },
+      {
+        "id": "proto-list@1.2.4",
+        "info": {
+          "name": "proto-list",
+          "version": "1.2.4"
+        }
+      },
+      {
+        "id": "config-chain@1.1.12",
+        "info": {
+          "name": "config-chain",
+          "version": "1.1.12"
+        }
+      },
+      {
+        "id": "minimist@0.0.8",
+        "info": {
+          "name": "minimist",
+          "version": "0.0.8"
+        }
+      },
+      {
+        "id": "mkdirp@0.5.1",
+        "info": {
+          "name": "mkdirp",
+          "version": "0.5.1"
+        }
+      },
+      {
+        "id": "abbrev@1.1.1",
+        "info": {
+          "name": "abbrev",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "nopt@3.0.6",
+        "info": {
+          "name": "nopt",
+          "version": "3.0.6"
+        }
+      },
+      {
+        "id": "once@1.3.3",
+        "info": {
+          "name": "once",
+          "version": "1.3.3"
+        }
+      },
+      {
+        "id": "os-homedir@1.0.2",
+        "info": {
+          "name": "os-homedir",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "os-tmpdir@1.0.2",
+        "info": {
+          "name": "os-tmpdir",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "osenv@0.1.5",
+        "info": {
+          "name": "osenv",
+          "version": "0.1.5"
+        }
+      },
+      {
+        "id": "semver@4.3.6",
+        "info": {
+          "name": "semver",
+          "version": "4.3.6"
+        }
+      },
+      {
+        "id": "uid-number@0.0.5",
+        "info": {
+          "name": "uid-number",
+          "version": "0.0.5"
+        }
+      },
+      {
+        "id": "npmconf@2.1.3",
+        "info": {
+          "name": "npmconf",
+          "version": "2.1.3"
+        }
+      },
+      {
+        "id": "optional@0.1.4",
+        "info": {
+          "name": "optional",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "id": "lodash@4.17.15",
+        "info": {
+          "name": "lodash",
+          "version": "4.17.15"
+        }
+      },
+      {
+        "id": "graphlib@2.1.7",
+        "info": {
+          "name": "graphlib",
+          "version": "2.1.7"
+        }
+      },
+      {
+        "id": "object-hash@1.3.1",
+        "info": {
+          "name": "object-hash",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "id": "semver@6.3.0",
+        "info": {
+          "name": "semver",
+          "version": "6.3.0"
+        }
+      },
+      {
+        "id": "buffer-from@1.1.1",
+        "info": {
+          "name": "buffer-from",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "source-map@0.6.1",
+        "info": {
+          "name": "source-map",
+          "version": "0.6.1"
+        }
+      },
+      {
+        "id": "source-map-support@0.5.13",
+        "info": {
+          "name": "source-map-support",
+          "version": "0.5.13"
+        }
+      },
+      {
+        "id": "tslib@1.10.0",
+        "info": {
+          "name": "tslib",
+          "version": "1.10.0"
+        }
+      },
+      {
+        "id": "@snyk/dep-graph@1.12.0",
+        "info": {
+          "name": "@snyk/dep-graph",
+          "version": "1.12.0"
+        }
+      },
+      {
+        "id": "@snyk/gemfile@1.2.0",
+        "info": {
+          "name": "@snyk/gemfile",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "@types/events@3.0.0",
+        "info": {
+          "name": "@types/events",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "@types/node@12.7.5",
+        "info": {
+          "name": "@types/node",
+          "version": "12.7.5"
+        }
+      },
+      {
+        "id": "@types/agent-base@4.2.0",
+        "info": {
+          "name": "@types/agent-base",
+          "version": "4.2.0"
+        }
+      },
+      {
+        "id": "@types/bunyan@1.8.6",
+        "info": {
+          "name": "@types/bunyan",
+          "version": "1.8.6"
+        }
+      },
+      {
+        "id": "@types/restify@4.3.6",
+        "info": {
+          "name": "@types/restify",
+          "version": "4.3.6"
+        }
+      },
+      {
+        "id": "ansi-escapes@3.2.0",
+        "info": {
+          "name": "ansi-escapes",
+          "version": "3.2.0"
+        }
+      },
+      {
+        "id": "color-name@1.1.3",
+        "info": {
+          "name": "color-name",
+          "version": "1.1.3"
+        }
+      },
+      {
+        "id": "color-convert@1.9.3",
+        "info": {
+          "name": "color-convert",
+          "version": "1.9.3"
+        }
+      },
+      {
+        "id": "ansi-styles@3.2.1",
+        "info": {
+          "name": "ansi-styles",
+          "version": "3.2.1"
+        }
+      },
+      {
+        "id": "escape-string-regexp@1.0.5",
+        "info": {
+          "name": "escape-string-regexp",
+          "version": "1.0.5"
+        }
+      },
+      {
+        "id": "has-flag@3.0.0",
+        "info": {
+          "name": "has-flag",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "supports-color@5.5.0",
+        "info": {
+          "name": "supports-color",
+          "version": "5.5.0"
+        }
+      },
+      {
+        "id": "chalk@2.4.2",
+        "info": {
+          "name": "chalk",
+          "version": "2.4.2"
+        }
+      },
+      {
+        "id": "is-obj@1.0.1",
+        "info": {
+          "name": "is-obj",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "dot-prop@4.2.0",
+        "info": {
+          "name": "dot-prop",
+          "version": "4.2.0"
+        }
+      },
+      {
+        "id": "pify@3.0.0",
+        "info": {
+          "name": "pify",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "make-dir@1.3.0",
+        "info": {
+          "name": "make-dir",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "id": "crypto-random-string@1.0.0",
+        "info": {
+          "name": "crypto-random-string",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "unique-string@1.0.0",
+        "info": {
+          "name": "unique-string",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "imurmurhash@0.1.4",
+        "info": {
+          "name": "imurmurhash",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "id": "signal-exit@3.0.2",
+        "info": {
+          "name": "signal-exit",
+          "version": "3.0.2"
+        }
+      },
+      {
+        "id": "write-file-atomic@2.4.3",
+        "info": {
+          "name": "write-file-atomic",
+          "version": "2.4.3"
+        }
+      },
+      {
+        "id": "xdg-basedir@3.0.0",
+        "info": {
+          "name": "xdg-basedir",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "configstore@3.1.2",
+        "info": {
+          "name": "configstore",
+          "version": "3.1.2"
+        }
+      },
+      {
+        "id": "ms@2.1.2",
+        "info": {
+          "name": "ms",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "id": "debug@3.2.6",
+        "info": {
+          "name": "debug",
+          "version": "3.2.6"
+        }
+      },
+      {
+        "id": "diff@4.0.1",
+        "info": {
+          "name": "diff",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "id": "protocols@1.4.7",
+        "info": {
+          "name": "protocols",
+          "version": "1.4.7"
+        }
+      },
+      {
+        "id": "is-ssh@1.3.1",
+        "info": {
+          "name": "is-ssh",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "id": "normalize-url@3.3.0",
+        "info": {
+          "name": "normalize-url",
+          "version": "3.3.0"
+        }
+      },
+      {
+        "id": "parse-path@4.0.1",
+        "info": {
+          "name": "parse-path",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "id": "parse-url@5.0.1",
+        "info": {
+          "name": "parse-url",
+          "version": "5.0.1"
+        }
+      },
+      {
+        "id": "git-up@4.0.1",
+        "info": {
+          "name": "git-up",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "id": "git-url-parse@11.1.2",
+        "info": {
+          "name": "git-url-parse",
+          "version": "11.1.2"
+        }
+      },
+      {
+        "id": "mimic-fn@1.2.0",
+        "info": {
+          "name": "mimic-fn",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "onetime@2.0.1",
+        "info": {
+          "name": "onetime",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "restore-cursor@2.0.0",
+        "info": {
+          "name": "restore-cursor",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "cli-cursor@2.1.0",
+        "info": {
+          "name": "cli-cursor",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "cli-width@2.2.0",
+        "info": {
+          "name": "cli-width",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "chardet@0.7.0",
+        "info": {
+          "name": "chardet",
+          "version": "0.7.0"
+        }
+      },
+      {
+        "id": "tmp@0.0.33",
+        "info": {
+          "name": "tmp",
+          "version": "0.0.33"
+        }
+      },
+      {
+        "id": "external-editor@3.1.0",
+        "info": {
+          "name": "external-editor",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "figures@2.0.0",
+        "info": {
+          "name": "figures",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "mute-stream@0.0.7",
+        "info": {
+          "name": "mute-stream",
+          "version": "0.0.7"
+        }
+      },
+      {
+        "id": "is-promise@2.1.0",
+        "info": {
+          "name": "is-promise",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "run-async@2.3.0",
+        "info": {
+          "name": "run-async",
+          "version": "2.3.0"
+        }
+      },
+      {
+        "id": "rxjs@6.5.3",
+        "info": {
+          "name": "rxjs",
+          "version": "6.5.3"
+        }
+      },
+      {
+        "id": "is-fullwidth-code-point@2.0.0",
+        "info": {
+          "name": "is-fullwidth-code-point",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "ansi-regex@3.0.0",
+        "info": {
+          "name": "ansi-regex",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "strip-ansi@4.0.0",
+        "info": {
+          "name": "strip-ansi",
+          "version": "4.0.0"
+        }
+      },
+      {
+        "id": "string-width@2.1.1",
+        "info": {
+          "name": "string-width",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "ansi-regex@4.1.0",
+        "info": {
+          "name": "ansi-regex",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "id": "strip-ansi@5.2.0",
+        "info": {
+          "name": "strip-ansi",
+          "version": "5.2.0"
+        }
+      },
+      {
+        "id": "through@2.3.8",
+        "info": {
+          "name": "through",
+          "version": "2.3.8"
+        }
+      },
+      {
+        "id": "inquirer@6.5.2",
+        "info": {
+          "name": "inquirer",
+          "version": "6.5.2"
+        }
+      },
+      {
+        "id": "is-wsl@1.1.0",
+        "info": {
+          "name": "is-wsl",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "opn@5.5.0",
+        "info": {
+          "name": "opn",
+          "version": "5.5.0"
+        }
+      },
+      {
+        "id": "macos-release@2.3.0",
+        "info": {
+          "name": "macos-release",
+          "version": "2.3.0"
+        }
+      },
+      {
+        "id": "nice-try@1.0.5",
+        "info": {
+          "name": "nice-try",
+          "version": "1.0.5"
+        }
+      },
+      {
+        "id": "path-key@2.0.1",
+        "info": {
+          "name": "path-key",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "shebang-regex@1.0.0",
+        "info": {
+          "name": "shebang-regex",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "shebang-command@1.2.0",
+        "info": {
+          "name": "shebang-command",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "isexe@2.0.0",
+        "info": {
+          "name": "isexe",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "which@1.3.1",
+        "info": {
+          "name": "which",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "id": "cross-spawn@6.0.5",
+        "info": {
+          "name": "cross-spawn",
+          "version": "6.0.5"
+        }
+      },
+      {
+        "id": "end-of-stream@1.4.2",
+        "info": {
+          "name": "end-of-stream",
+          "version": "1.4.2"
+        }
+      },
+      {
+        "id": "pump@3.0.0",
+        "info": {
+          "name": "pump",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "get-stream@4.1.0",
+        "info": {
+          "name": "get-stream",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "id": "is-stream@1.1.0",
+        "info": {
+          "name": "is-stream",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "npm-run-path@2.0.2",
+        "info": {
+          "name": "npm-run-path",
+          "version": "2.0.2"
+        }
+      },
+      {
+        "id": "p-finally@1.0.0",
+        "info": {
+          "name": "p-finally",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "strip-eof@1.0.0",
+        "info": {
+          "name": "strip-eof",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "execa@1.0.0",
+        "info": {
+          "name": "execa",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "windows-release@3.2.0",
+        "info": {
+          "name": "windows-release",
+          "version": "3.2.0"
+        }
+      },
+      {
+        "id": "os-name@3.1.0",
+        "info": {
+          "name": "os-name",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "es6-promise@4.2.8",
+        "info": {
+          "name": "es6-promise",
+          "version": "4.2.8"
+        }
+      },
+      {
+        "id": "es6-promisify@5.0.0",
+        "info": {
+          "name": "es6-promisify",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "agent-base@4.3.0",
+        "info": {
+          "name": "agent-base",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "http-proxy-agent@2.1.0",
+        "info": {
+          "name": "http-proxy-agent",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "https-proxy-agent@2.2.2",
+        "info": {
+          "name": "https-proxy-agent",
+          "version": "2.2.2"
+        }
+      },
+      {
+        "id": "pseudomap@1.0.2",
+        "info": {
+          "name": "pseudomap",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "yallist@2.1.2",
+        "info": {
+          "name": "yallist",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "id": "lru-cache@4.1.5",
+        "info": {
+          "name": "lru-cache",
+          "version": "4.1.5"
+        }
+      },
+      {
+        "id": "@types/node@8.10.54",
+        "info": {
+          "name": "@types/node",
+          "version": "8.10.54"
+        }
+      },
+      {
+        "id": "data-uri-to-buffer@2.0.1",
+        "info": {
+          "name": "data-uri-to-buffer",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "extend@3.0.2",
+        "info": {
+          "name": "extend",
+          "version": "3.0.2"
+        }
+      },
+      {
+        "id": "file-uri-to-path@1.0.0",
+        "info": {
+          "name": "file-uri-to-path",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "core-util-is@1.0.2",
+        "info": {
+          "name": "core-util-is",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "isarray@0.0.1",
+        "info": {
+          "name": "isarray",
+          "version": "0.0.1"
+        }
+      },
+      {
+        "id": "string_decoder@0.10.31",
+        "info": {
+          "name": "string_decoder",
+          "version": "0.10.31"
+        }
+      },
+      {
+        "id": "readable-stream@1.1.14",
+        "info": {
+          "name": "readable-stream",
+          "version": "1.1.14"
+        }
+      },
+      {
+        "id": "xregexp@2.0.0",
+        "info": {
+          "name": "xregexp",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "ftp@0.3.10",
+        "info": {
+          "name": "ftp",
+          "version": "0.3.10"
+        }
+      },
+      {
+        "id": "safe-buffer@5.2.0",
+        "info": {
+          "name": "safe-buffer",
+          "version": "5.2.0"
+        }
+      },
+      {
+        "id": "string_decoder@1.3.0",
+        "info": {
+          "name": "string_decoder",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "id": "util-deprecate@1.0.2",
+        "info": {
+          "name": "util-deprecate",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "readable-stream@3.4.0",
+        "info": {
+          "name": "readable-stream",
+          "version": "3.4.0"
+        }
+      },
+      {
+        "id": "get-uri@2.0.3",
+        "info": {
+          "name": "get-uri",
+          "version": "2.0.3"
+        }
+      },
+      {
+        "id": "co@4.6.0",
+        "info": {
+          "name": "co",
+          "version": "4.6.0"
+        }
+      },
+      {
+        "id": "ast-types@0.13.2",
+        "info": {
+          "name": "ast-types",
+          "version": "0.13.2"
+        }
+      },
+      {
+        "id": "esprima@3.1.3",
+        "info": {
+          "name": "esprima",
+          "version": "3.1.3"
+        }
+      },
+      {
+        "id": "estraverse@4.3.0",
+        "info": {
+          "name": "estraverse",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "esutils@2.0.3",
+        "info": {
+          "name": "esutils",
+          "version": "2.0.3"
+        }
+      },
+      {
+        "id": "deep-is@0.1.3",
+        "info": {
+          "name": "deep-is",
+          "version": "0.1.3"
+        }
+      },
+      {
+        "id": "fast-levenshtein@2.0.6",
+        "info": {
+          "name": "fast-levenshtein",
+          "version": "2.0.6"
+        }
+      },
+      {
+        "id": "prelude-ls@1.1.2",
+        "info": {
+          "name": "prelude-ls",
+          "version": "1.1.2"
+        }
+      },
+      {
+        "id": "type-check@0.3.2",
+        "info": {
+          "name": "type-check",
+          "version": "0.3.2"
+        }
+      },
+      {
+        "id": "levn@0.3.0",
+        "info": {
+          "name": "levn",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "id": "wordwrap@1.0.0",
+        "info": {
+          "name": "wordwrap",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "optionator@0.8.2",
+        "info": {
+          "name": "optionator",
+          "version": "0.8.2"
+        }
+      },
+      {
+        "id": "escodegen@1.12.0",
+        "info": {
+          "name": "escodegen",
+          "version": "1.12.0"
+        }
+      },
+      {
+        "id": "degenerator@1.0.4",
+        "info": {
+          "name": "degenerator",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "id": "ip@1.1.5",
+        "info": {
+          "name": "ip",
+          "version": "1.1.5"
+        }
+      },
+      {
+        "id": "netmask@1.0.6",
+        "info": {
+          "name": "netmask",
+          "version": "1.0.6"
+        }
+      },
+      {
+        "id": "thunkify@2.1.2",
+        "info": {
+          "name": "thunkify",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "id": "pac-resolver@3.0.0",
+        "info": {
+          "name": "pac-resolver",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "bytes@3.1.0",
+        "info": {
+          "name": "bytes",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "inherits@2.0.4",
+        "info": {
+          "name": "inherits",
+          "version": "2.0.4"
+        }
+      },
+      {
+        "id": "setprototypeof@1.1.1",
+        "info": {
+          "name": "setprototypeof",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "toidentifier@1.0.0",
+        "info": {
+          "name": "toidentifier",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "http-errors@1.7.3",
+        "info": {
+          "name": "http-errors",
+          "version": "1.7.3"
+        }
+      },
+      {
+        "id": "raw-body@2.4.1",
+        "info": {
+          "name": "raw-body",
+          "version": "2.4.1"
+        }
+      },
+      {
+        "id": "agent-base@4.2.1",
+        "info": {
+          "name": "agent-base",
+          "version": "4.2.1"
+        }
+      },
+      {
+        "id": "smart-buffer@4.0.2",
+        "info": {
+          "name": "smart-buffer",
+          "version": "4.0.2"
+        }
+      },
+      {
+        "id": "socks@2.3.2",
+        "info": {
+          "name": "socks",
+          "version": "2.3.2"
+        }
+      },
+      {
+        "id": "socks-proxy-agent@4.0.2",
+        "info": {
+          "name": "socks-proxy-agent",
+          "version": "4.0.2"
+        }
+      },
+      {
+        "id": "pac-proxy-agent@3.0.0",
+        "info": {
+          "name": "pac-proxy-agent",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "proxy-from-env@1.0.0",
+        "info": {
+          "name": "proxy-from-env",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "proxy-agent@3.1.0",
+        "info": {
+          "name": "proxy-agent",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "async@1.5.2",
+        "info": {
+          "name": "async",
+          "version": "1.5.2"
+        }
+      },
+      {
+        "id": "secure-keys@1.0.0",
+        "info": {
+          "name": "secure-keys",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "camelcase@2.1.1",
+        "info": {
+          "name": "camelcase",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "code-point-at@1.1.0",
+        "info": {
+          "name": "code-point-at",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "number-is-nan@1.0.1",
+        "info": {
+          "name": "number-is-nan",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "is-fullwidth-code-point@1.0.0",
+        "info": {
+          "name": "is-fullwidth-code-point",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "ansi-regex@2.1.1",
+        "info": {
+          "name": "ansi-regex",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "strip-ansi@3.0.1",
+        "info": {
+          "name": "strip-ansi",
+          "version": "3.0.1"
+        }
+      },
+      {
+        "id": "string-width@1.0.2",
+        "info": {
+          "name": "string-width",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "wrap-ansi@2.1.0",
+        "info": {
+          "name": "wrap-ansi",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "cliui@3.2.0",
+        "info": {
+          "name": "cliui",
+          "version": "3.2.0"
+        }
+      },
+      {
+        "id": "decamelize@1.2.0",
+        "info": {
+          "name": "decamelize",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "invert-kv@1.0.0",
+        "info": {
+          "name": "invert-kv",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "lcid@1.0.0",
+        "info": {
+          "name": "lcid",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "os-locale@1.4.0",
+        "info": {
+          "name": "os-locale",
+          "version": "1.4.0"
+        }
+      },
+      {
+        "id": "window-size@0.1.4",
+        "info": {
+          "name": "window-size",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "id": "y18n@3.2.1",
+        "info": {
+          "name": "y18n",
+          "version": "3.2.1"
+        }
+      },
+      {
+        "id": "yargs@3.32.0",
+        "info": {
+          "name": "yargs",
+          "version": "3.32.0"
+        }
+      },
+      {
+        "id": "nconf@0.10.0",
+        "info": {
+          "name": "nconf",
+          "version": "0.10.0"
+        }
+      },
+      {
+        "id": "snyk-config@2.2.3",
+        "info": {
+          "name": "snyk-config",
+          "version": "2.2.3"
+        }
+      },
+      {
+        "id": "debug@4.1.1",
+        "info": {
+          "name": "debug",
+          "version": "4.1.1"
+        }
+      },
+      {
+        "id": "vscode-languageserver-types@3.14.0",
+        "info": {
+          "name": "vscode-languageserver-types",
+          "version": "3.14.0"
+        }
+      },
+      {
+        "id": "dockerfile-ast@0.0.16",
+        "info": {
+          "name": "dockerfile-ast",
+          "version": "0.0.16"
+        }
+      },
+      {
+        "id": "snyk-docker-plugin@1.29.1",
+        "info": {
+          "name": "snyk-docker-plugin",
+          "version": "1.29.1"
+        }
+      },
+      {
+        "id": "toml@3.0.0",
+        "info": {
+          "name": "toml",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "snyk-go-parser@1.3.1",
+        "info": {
+          "name": "snyk-go-parser",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "id": "snyk-go-plugin@1.11.0",
+        "info": {
+          "name": "snyk-go-plugin",
+          "version": "1.11.0"
+        }
+      },
+      {
+        "id": "@snyk/cli-interface@2.1.0",
+        "info": {
+          "name": "@snyk/cli-interface",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "@types/debug@4.1.5",
+        "info": {
+          "name": "@types/debug",
+          "version": "4.1.5"
+        }
+      },
+      {
+        "id": "for-in@1.0.2",
+        "info": {
+          "name": "for-in",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "for-own@1.0.0",
+        "info": {
+          "name": "for-own",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "isobject@3.0.1",
+        "info": {
+          "name": "isobject",
+          "version": "3.0.1"
+        }
+      },
+      {
+        "id": "is-plain-object@2.0.4",
+        "info": {
+          "name": "is-plain-object",
+          "version": "2.0.4"
+        }
+      },
+      {
+        "id": "is-buffer@1.1.6",
+        "info": {
+          "name": "is-buffer",
+          "version": "1.1.6"
+        }
+      },
+      {
+        "id": "kind-of@3.2.2",
+        "info": {
+          "name": "kind-of",
+          "version": "3.2.2"
+        }
+      },
+      {
+        "id": "is-extendable@0.1.1",
+        "info": {
+          "name": "is-extendable",
+          "version": "0.1.1"
+        }
+      },
+      {
+        "id": "kind-of@2.0.1",
+        "info": {
+          "name": "kind-of",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "lazy-cache@0.2.7",
+        "info": {
+          "name": "lazy-cache",
+          "version": "0.2.7"
+        }
+      },
+      {
+        "id": "for-in@0.1.8",
+        "info": {
+          "name": "for-in",
+          "version": "0.1.8"
+        }
+      },
+      {
+        "id": "mixin-object@2.0.1",
+        "info": {
+          "name": "mixin-object",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "shallow-clone@0.1.2",
+        "info": {
+          "name": "shallow-clone",
+          "version": "0.1.2"
+        }
+      },
+      {
+        "id": "clone-deep@0.3.0",
+        "info": {
+          "name": "clone-deep",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "id": "snyk-gradle-plugin@3.1.0",
+        "info": {
+          "name": "snyk-gradle-plugin",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "hosted-git-info@2.8.4",
+        "info": {
+          "name": "hosted-git-info",
+          "version": "2.8.4"
+        }
+      },
+      {
+        "id": "snyk-module@1.9.1",
+        "info": {
+          "name": "snyk-module",
+          "version": "1.9.1"
+        }
+      },
+      {
+        "id": "tslib@1.9.3",
+        "info": {
+          "name": "tslib",
+          "version": "1.9.3"
+        }
+      },
+      {
+        "id": "snyk-mvn-plugin@2.4.0",
+        "info": {
+          "name": "snyk-mvn-plugin",
+          "version": "2.4.0"
+        }
+      },
+      {
+        "id": "@yarnpkg/lockfile@1.1.0",
+        "info": {
+          "name": "@yarnpkg/lockfile",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "uuid@3.3.3",
+        "info": {
+          "name": "uuid",
+          "version": "3.3.3"
+        }
+      },
+      {
+        "id": "snyk-nodejs-lockfile-parser@1.16.0",
+        "info": {
+          "name": "snyk-nodejs-lockfile-parser",
+          "version": "1.16.0"
+        }
+      },
+      {
+        "id": "@types/xml2js@0.4.3",
+        "info": {
+          "name": "@types/xml2js",
+          "version": "0.4.3"
+        }
+      },
+      {
+        "id": "xmlbuilder@9.0.7",
+        "info": {
+          "name": "xmlbuilder",
+          "version": "9.0.7"
+        }
+      },
+      {
+        "id": "xml2js@0.4.19",
+        "info": {
+          "name": "xml2js",
+          "version": "0.4.19"
+        }
+      },
+      {
+        "id": "dotnet-deps-parser@4.5.0",
+        "info": {
+          "name": "dotnet-deps-parser",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "id": "immediate@3.0.6",
+        "info": {
+          "name": "immediate",
+          "version": "3.0.6"
+        }
+      },
+      {
+        "id": "lie@3.3.0",
+        "info": {
+          "name": "lie",
+          "version": "3.3.0"
+        }
+      },
+      {
+        "id": "pako@1.0.10",
+        "info": {
+          "name": "pako",
+          "version": "1.0.10"
+        }
+      },
+      {
+        "id": "isarray@1.0.0",
+        "info": {
+          "name": "isarray",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "process-nextick-args@2.0.0",
+        "info": {
+          "name": "process-nextick-args",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "string_decoder@1.1.1",
+        "info": {
+          "name": "string_decoder",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "readable-stream@2.3.6",
+        "info": {
+          "name": "readable-stream",
+          "version": "2.3.6"
+        }
+      },
+      {
+        "id": "set-immediate-shim@1.0.1",
+        "info": {
+          "name": "set-immediate-shim",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "jszip@3.2.2",
+        "info": {
+          "name": "jszip",
+          "version": "3.2.2"
+        }
+      },
+      {
+        "id": "snyk-paket-parser@1.5.0",
+        "info": {
+          "name": "snyk-paket-parser",
+          "version": "1.5.0"
+        }
+      },
+      {
+        "id": "object-keys@1.1.1",
+        "info": {
+          "name": "object-keys",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "define-properties@1.1.3",
+        "info": {
+          "name": "define-properties",
+          "version": "1.1.3"
+        }
+      },
+      {
+        "id": "is-callable@1.1.4",
+        "info": {
+          "name": "is-callable",
+          "version": "1.1.4"
+        }
+      },
+      {
+        "id": "is-date-object@1.0.1",
+        "info": {
+          "name": "is-date-object",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "has-symbols@1.0.0",
+        "info": {
+          "name": "has-symbols",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "is-symbol@1.0.2",
+        "info": {
+          "name": "is-symbol",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "es-to-primitive@1.2.0",
+        "info": {
+          "name": "es-to-primitive",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "function-bind@1.1.1",
+        "info": {
+          "name": "function-bind",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "has@1.0.3",
+        "info": {
+          "name": "has",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "id": "is-regex@1.0.4",
+        "info": {
+          "name": "is-regex",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "id": "object-inspect@1.6.0",
+        "info": {
+          "name": "object-inspect",
+          "version": "1.6.0"
+        }
+      },
+      {
+        "id": "string.prototype.trimleft@2.1.0",
+        "info": {
+          "name": "string.prototype.trimleft",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "string.prototype.trimright@2.1.0",
+        "info": {
+          "name": "string.prototype.trimright",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "es-abstract@1.14.2",
+        "info": {
+          "name": "es-abstract",
+          "version": "1.14.2"
+        }
+      },
+      {
+        "id": "object.getownpropertydescriptors@2.0.3",
+        "info": {
+          "name": "object.getownpropertydescriptors",
+          "version": "2.0.3"
+        }
+      },
+      {
+        "id": "util.promisify@1.0.0",
+        "info": {
+          "name": "util.promisify",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "xmlbuilder@11.0.1",
+        "info": {
+          "name": "xmlbuilder",
+          "version": "11.0.1"
+        }
+      },
+      {
+        "id": "xml2js@0.4.22",
+        "info": {
+          "name": "xml2js",
+          "version": "0.4.22"
+        }
+      },
+      {
+        "id": "snyk-nuget-plugin@1.12.1",
+        "info": {
+          "name": "snyk-nuget-plugin",
+          "version": "1.12.1"
+        }
+      },
+      {
+        "id": "@snyk/composer-lockfile-parser@1.0.3",
+        "info": {
+          "name": "@snyk/composer-lockfile-parser",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "id": "snyk-php-plugin@1.6.4",
+        "info": {
+          "name": "snyk-php-plugin",
+          "version": "1.6.4"
+        }
+      },
+      {
+        "id": "email-validator@2.0.4",
+        "info": {
+          "name": "email-validator",
+          "version": "2.0.4"
+        }
+      },
+      {
+        "id": "lodash.clonedeep@4.5.0",
+        "info": {
+          "name": "lodash.clonedeep",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "id": "asap@2.0.6",
+        "info": {
+          "name": "asap",
+          "version": "2.0.6"
+        }
+      },
+      {
+        "id": "promise@7.3.1",
+        "info": {
+          "name": "promise",
+          "version": "7.3.1"
+        }
+      },
+      {
+        "id": "then-fs@2.0.0",
+        "info": {
+          "name": "then-fs",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "snyk-resolve@1.0.1",
+        "info": {
+          "name": "snyk-resolve",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "snyk-try-require@1.3.1",
+        "info": {
+          "name": "snyk-try-require",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "id": "snyk-policy@1.13.5",
+        "info": {
+          "name": "snyk-policy",
+          "version": "1.13.5"
+        }
+      },
+      {
+        "id": "snyk-python-plugin@1.13.2",
+        "info": {
+          "name": "snyk-python-plugin",
+          "version": "1.13.2"
+        }
+      },
+      {
+        "id": "@types/node@6.14.7",
+        "info": {
+          "name": "@types/node",
+          "version": "6.14.7"
+        }
+      },
+      {
+        "id": "@types/semver@5.5.0",
+        "info": {
+          "name": "@types/semver",
+          "version": "5.5.0"
+        }
+      },
+      {
+        "id": "ansicolors@0.3.2",
+        "info": {
+          "name": "ansicolors",
+          "version": "0.3.2"
+        }
+      },
+      {
+        "id": "lodash.assign@4.2.0",
+        "info": {
+          "name": "lodash.assign",
+          "version": "4.2.0"
+        }
+      },
+      {
+        "id": "lodash.assignin@4.2.0",
+        "info": {
+          "name": "lodash.assignin",
+          "version": "4.2.0"
+        }
+      },
+      {
+        "id": "lodash.clone@4.5.0",
+        "info": {
+          "name": "lodash.clone",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "id": "lodash.flatten@4.4.0",
+        "info": {
+          "name": "lodash.flatten",
+          "version": "4.4.0"
+        }
+      },
+      {
+        "id": "lodash.get@4.4.2",
+        "info": {
+          "name": "lodash.get",
+          "version": "4.4.2"
+        }
+      },
+      {
+        "id": "lodash.set@4.3.2",
+        "info": {
+          "name": "lodash.set",
+          "version": "4.3.2"
+        }
+      },
+      {
+        "id": "archy@1.0.0",
+        "info": {
+          "name": "archy",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "snyk-tree@1.0.0",
+        "info": {
+          "name": "snyk-tree",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "snyk-resolve-deps@4.4.0",
+        "info": {
+          "name": "snyk-resolve-deps",
+          "version": "4.4.0"
+        }
+      },
+      {
+        "id": "tmp@0.1.0",
+        "info": {
+          "name": "tmp",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "id": "tree-kill@1.2.1",
+        "info": {
+          "name": "tree-kill",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "id": "snyk-sbt-plugin@2.8.0",
+        "info": {
+          "name": "snyk-sbt-plugin",
+          "version": "2.8.0"
+        }
+      },
+      {
+        "id": "temp-dir@1.0.0",
+        "info": {
+          "name": "temp-dir",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "tempfile@2.0.0",
+        "info": {
+          "name": "tempfile",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "ansi-align@2.0.0",
+        "info": {
+          "name": "ansi-align",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "camelcase@4.1.0",
+        "info": {
+          "name": "camelcase",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "id": "cli-boxes@1.0.0",
+        "info": {
+          "name": "cli-boxes",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "cross-spawn@5.1.0",
+        "info": {
+          "name": "cross-spawn",
+          "version": "5.1.0"
+        }
+      },
+      {
+        "id": "get-stream@3.0.0",
+        "info": {
+          "name": "get-stream",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "execa@0.7.0",
+        "info": {
+          "name": "execa",
+          "version": "0.7.0"
+        }
+      },
+      {
+        "id": "term-size@1.2.0",
+        "info": {
+          "name": "term-size",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "widest-line@2.0.1",
+        "info": {
+          "name": "widest-line",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "boxen@1.3.0",
+        "info": {
+          "name": "boxen",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "id": "import-lazy@2.1.0",
+        "info": {
+          "name": "import-lazy",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "ci-info@1.6.0",
+        "info": {
+          "name": "ci-info",
+          "version": "1.6.0"
+        }
+      },
+      {
+        "id": "is-ci@1.2.1",
+        "info": {
+          "name": "is-ci",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "id": "global-dirs@0.1.1",
+        "info": {
+          "name": "global-dirs",
+          "version": "0.1.1"
+        }
+      },
+      {
+        "id": "path-is-inside@1.0.2",
+        "info": {
+          "name": "path-is-inside",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "is-path-inside@1.0.1",
+        "info": {
+          "name": "is-path-inside",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "is-installed-globally@0.1.0",
+        "info": {
+          "name": "is-installed-globally",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "id": "is-npm@1.0.0",
+        "info": {
+          "name": "is-npm",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "capture-stack-trace@1.0.1",
+        "info": {
+          "name": "capture-stack-trace",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "create-error-class@3.0.2",
+        "info": {
+          "name": "create-error-class",
+          "version": "3.0.2"
+        }
+      },
+      {
+        "id": "duplexer3@0.1.4",
+        "info": {
+          "name": "duplexer3",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "id": "is-redirect@1.0.0",
+        "info": {
+          "name": "is-redirect",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "is-retry-allowed@1.2.0",
+        "info": {
+          "name": "is-retry-allowed",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "lowercase-keys@1.0.1",
+        "info": {
+          "name": "lowercase-keys",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "timed-out@4.0.1",
+        "info": {
+          "name": "timed-out",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "id": "unzip-response@2.0.1",
+        "info": {
+          "name": "unzip-response",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "prepend-http@1.0.4",
+        "info": {
+          "name": "prepend-http",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "id": "url-parse-lax@1.0.0",
+        "info": {
+          "name": "url-parse-lax",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "got@6.7.1",
+        "info": {
+          "name": "got",
+          "version": "6.7.1"
+        }
+      },
+      {
+        "id": "deep-extend@0.6.0",
+        "info": {
+          "name": "deep-extend",
+          "version": "0.6.0"
+        }
+      },
+      {
+        "id": "minimist@1.2.0",
+        "info": {
+          "name": "minimist",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "strip-json-comments@2.0.1",
+        "info": {
+          "name": "strip-json-comments",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "rc@1.2.8",
+        "info": {
+          "name": "rc",
+          "version": "1.2.8"
+        }
+      },
+      {
+        "id": "registry-auth-token@3.4.0",
+        "info": {
+          "name": "registry-auth-token",
+          "version": "3.4.0"
+        }
+      },
+      {
+        "id": "registry-url@3.1.0",
+        "info": {
+          "name": "registry-url",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "package-json@4.0.1",
+        "info": {
+          "name": "package-json",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "id": "latest-version@3.1.0",
+        "info": {
+          "name": "latest-version",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "semver-diff@2.1.0",
+        "info": {
+          "name": "semver-diff",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "update-notifier@2.5.0",
+        "info": {
+          "name": "update-notifier",
+          "version": "2.5.0"
+        }
+      },
+      {
+        "id": "emoji-regex@7.0.3",
+        "info": {
+          "name": "emoji-regex",
+          "version": "7.0.3"
+        }
+      },
+      {
+        "id": "string-width@3.1.0",
+        "info": {
+          "name": "string-width",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "wrap-ansi@5.1.0",
+        "info": {
+          "name": "wrap-ansi",
+          "version": "5.1.0"
+        }
+      },
+      {
+        "id": "snyk@1.228.3",
+        "info": {
+          "name": "snyk",
+          "version": "1.228.3"
+        }
+      },
+      {
+        "id": "async-cache@1.1.0",
+        "info": {
+          "name": "async-cache",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "bl@1.2.2",
+        "info": {
+          "name": "bl",
+          "version": "1.2.2"
+        }
+      },
+      {
+        "id": "fd@0.0.3",
+        "info": {
+          "name": "fd",
+          "version": "0.0.3"
+        }
+      },
+      {
+        "id": "st@1.2.2",
+        "info": {
+          "name": "st",
+          "version": "1.2.2"
+        }
+      },
+      {
+        "id": "stream-buffers@3.0.2",
+        "info": {
+          "name": "stream-buffers",
+          "version": "3.0.2"
+        }
+      },
+      {
+        "id": "ansi-styles@2.2.1",
+        "info": {
+          "name": "ansi-styles",
+          "version": "2.2.1"
+        }
+      },
+      {
+        "id": "has-ansi@2.0.0",
+        "info": {
+          "name": "has-ansi",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "supports-color@2.0.0",
+        "info": {
+          "name": "supports-color",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "chalk@1.1.3",
+        "info": {
+          "name": "chalk",
+          "version": "1.1.3"
+        }
+      },
+      {
+        "id": "js-tokens@3.0.2",
+        "info": {
+          "name": "js-tokens",
+          "version": "3.0.2"
+        }
+      },
+      {
+        "id": "babel-code-frame@6.26.0",
+        "info": {
+          "name": "babel-code-frame",
+          "version": "6.26.0"
+        }
+      },
+      {
+        "id": "colors@1.4.0",
+        "info": {
+          "name": "colors",
+          "version": "1.4.0"
+        }
+      },
+      {
+        "id": "diff@3.5.0",
+        "info": {
+          "name": "diff",
+          "version": "3.5.0"
+        }
+      },
+      {
+        "id": "glob@5.0.15",
+        "info": {
+          "name": "glob",
+          "version": "5.0.15"
+        }
+      },
+      {
+        "id": "findup-sync@0.3.0",
+        "info": {
+          "name": "findup-sync",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "id": "minimist@0.0.10",
+        "info": {
+          "name": "minimist",
+          "version": "0.0.10"
+        }
+      },
+      {
+        "id": "wordwrap@0.0.3",
+        "info": {
+          "name": "wordwrap",
+          "version": "0.0.3"
+        }
+      },
+      {
+        "id": "optimist@0.6.1",
+        "info": {
+          "name": "optimist",
+          "version": "0.6.1"
+        }
+      },
+      {
+        "id": "path-parse@1.0.6",
+        "info": {
+          "name": "path-parse",
+          "version": "1.0.6"
+        }
+      },
+      {
+        "id": "resolve@1.8.1",
+        "info": {
+          "name": "resolve",
+          "version": "1.8.1"
+        }
+      },
+      {
+        "id": "tsutils@1.9.1",
+        "info": {
+          "name": "tsutils",
+          "version": "1.9.1"
+        }
+      },
+      {
+        "id": "tslint@5.1.0",
+        "info": {
+          "name": "tslint",
+          "version": "5.1.0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "goof@0.0.3",
+          "deps": [
+            {
+              "nodeId": "@snyk/nodejs-runtime-agent@1.14.0"
+            },
+            {
+              "nodeId": "cfenv@1.2.1"
+            },
+            {
+              "nodeId": "consolidate@0.14.5"
+            },
+            {
+              "nodeId": "cookie-parser@1.3.3"
+            },
+            {
+              "nodeId": "dustjs-helpers@1.5.0"
+            },
+            {
+              "nodeId": "ejs@2.5.5"
+            },
+            {
+              "nodeId": "ejs-locals@1.0.2"
+            },
+            {
+              "nodeId": "express@4.16.0"
+            },
+            {
+              "nodeId": "express-fileupload@0.0.5"
+            },
+            {
+              "nodeId": "humanize-ms@1.0.1"
+            },
+            {
+              "nodeId": "method-override@3.0.0"
+            },
+            {
+              "nodeId": "moment@2.19.3"
+            },
+            {
+              "nodeId": "morgan@1.9.1"
+            },
+            {
+              "nodeId": "ms@2.0.0"
+            },
+            {
+              "nodeId": "npmconf@2.1.3"
+            },
+            {
+              "nodeId": "optional@0.1.4"
+            },
+            {
+              "nodeId": "snyk@1.228.3"
+            },
+            {
+              "nodeId": "st@1.2.2"
+            },
+            {
+              "nodeId": "stream-buffers@3.0.2"
+            },
+            {
+              "nodeId": "tslint@5.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "acorn@5.7.3",
+          "pkgId": "acorn@5.7.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ms@2.1.1",
+          "pkgId": "ms@2.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "debug@4.1.0",
+          "pkgId": "debug@4.1.0",
+          "deps": [
+            {
+              "nodeId": "ms@2.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ms@2.0.0",
+          "pkgId": "ms@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "debug@2.6.9",
+          "pkgId": "debug@2.6.9",
+          "deps": [
+            {
+              "nodeId": "ms@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "safer-buffer@2.1.2",
+          "pkgId": "safer-buffer@2.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "iconv-lite@0.4.24",
+          "pkgId": "iconv-lite@0.4.24",
+          "deps": [
+            {
+              "nodeId": "safer-buffer@2.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "sax@1.2.4",
+          "pkgId": "sax@1.2.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "needle@2.2.4",
+          "pkgId": "needle@2.2.4",
+          "deps": [
+            {
+              "nodeId": "debug@2.6.9"
+            },
+            {
+              "nodeId": "iconv-lite@0.4.24"
+            },
+            {
+              "nodeId": "sax@1.2.4"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "semver@5.6.0",
+          "pkgId": "semver@5.6.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/nodejs-runtime-agent@1.14.0",
+          "pkgId": "@snyk/nodejs-runtime-agent@1.14.0",
+          "deps": [
+            {
+              "nodeId": "acorn@5.7.3"
+            },
+            {
+              "nodeId": "debug@4.1.0"
+            },
+            {
+              "nodeId": "needle@2.2.4"
+            },
+            {
+              "nodeId": "semver@5.6.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "sprintf-js@1.0.3",
+          "pkgId": "sprintf-js@1.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "argparse@1.0.10",
+          "pkgId": "argparse@1.0.10",
+          "deps": [
+            {
+              "nodeId": "sprintf-js@1.0.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "esprima@4.0.1",
+          "pkgId": "esprima@4.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "js-yaml@3.13.1",
+          "pkgId": "js-yaml@3.13.1",
+          "deps": [
+            {
+              "nodeId": "argparse@1.0.10"
+            },
+            {
+              "nodeId": "esprima@4.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ports@1.1.0",
+          "pkgId": "ports@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "underscore@1.9.1",
+          "pkgId": "underscore@1.9.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cfenv@1.2.1",
+          "pkgId": "cfenv@1.2.1",
+          "deps": [
+            {
+              "nodeId": "js-yaml@3.13.1"
+            },
+            {
+              "nodeId": "ports@1.1.0"
+            },
+            {
+              "nodeId": "underscore@1.9.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "bluebird@3.5.3",
+          "pkgId": "bluebird@3.5.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "consolidate@0.14.5",
+          "pkgId": "consolidate@0.14.5",
+          "deps": [
+            {
+              "nodeId": "bluebird@3.5.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cookie@0.1.2",
+          "pkgId": "cookie@0.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cookie-signature@1.0.5",
+          "pkgId": "cookie-signature@1.0.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cookie-parser@1.3.3",
+          "pkgId": "cookie-parser@1.3.3",
+          "deps": [
+            {
+              "nodeId": "cookie@0.1.2"
+            },
+            {
+              "nodeId": "cookie-signature@1.0.5"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "dustjs-helpers@1.5.0",
+          "pkgId": "dustjs-helpers@1.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ejs@2.5.5",
+          "pkgId": "ejs@2.5.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ejs@0.8.8",
+          "pkgId": "ejs@0.8.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ejs-locals@1.0.2",
+          "pkgId": "ejs-locals@1.0.2",
+          "deps": [
+            {
+              "nodeId": "ejs@0.8.8"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "mime-db@1.40.0",
+          "pkgId": "mime-db@1.40.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "mime-types@2.1.24",
+          "pkgId": "mime-types@2.1.24",
+          "deps": [
+            {
+              "nodeId": "mime-db@1.40.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "negotiator@0.6.2",
+          "pkgId": "negotiator@0.6.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "accepts@1.3.7",
+          "pkgId": "accepts@1.3.7",
+          "deps": [
+            {
+              "nodeId": "mime-types@2.1.24"
+            },
+            {
+              "nodeId": "negotiator@0.6.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "array-flatten@1.1.1",
+          "pkgId": "array-flatten@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "bytes@3.0.0",
+          "pkgId": "bytes@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "content-type@1.0.4",
+          "pkgId": "content-type@1.0.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "depd@1.1.2",
+          "pkgId": "depd@1.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "inherits@2.0.3",
+          "pkgId": "inherits@2.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "setprototypeof@1.1.0",
+          "pkgId": "setprototypeof@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "statuses@1.5.0",
+          "pkgId": "statuses@1.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "http-errors@1.6.3",
+          "pkgId": "http-errors@1.6.3",
+          "deps": [
+            {
+              "nodeId": "depd@1.1.2"
+            },
+            {
+              "nodeId": "inherits@2.0.3"
+            },
+            {
+              "nodeId": "setprototypeof@1.1.0"
+            },
+            {
+              "nodeId": "statuses@1.5.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "iconv-lite@0.4.19",
+          "pkgId": "iconv-lite@0.4.19",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ee-first@1.1.1",
+          "pkgId": "ee-first@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "on-finished@2.3.0",
+          "pkgId": "on-finished@2.3.0",
+          "deps": [
+            {
+              "nodeId": "ee-first@1.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "qs@6.5.1",
+          "pkgId": "qs@6.5.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "depd@1.1.1",
+          "pkgId": "depd@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "setprototypeof@1.0.3",
+          "pkgId": "setprototypeof@1.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "statuses@1.3.1",
+          "pkgId": "statuses@1.3.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "http-errors@1.6.2",
+          "pkgId": "http-errors@1.6.2",
+          "deps": [
+            {
+              "nodeId": "depd@1.1.1"
+            },
+            {
+              "nodeId": "inherits@2.0.3"
+            },
+            {
+              "nodeId": "setprototypeof@1.0.3"
+            },
+            {
+              "nodeId": "statuses@1.3.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "unpipe@1.0.0",
+          "pkgId": "unpipe@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "raw-body@2.3.2",
+          "pkgId": "raw-body@2.3.2",
+          "deps": [
+            {
+              "nodeId": "bytes@3.0.0"
+            },
+            {
+              "nodeId": "http-errors@1.6.2"
+            },
+            {
+              "nodeId": "iconv-lite@0.4.19"
+            },
+            {
+              "nodeId": "unpipe@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "media-typer@0.3.0",
+          "pkgId": "media-typer@0.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "type-is@1.6.18",
+          "pkgId": "type-is@1.6.18",
+          "deps": [
+            {
+              "nodeId": "media-typer@0.3.0"
+            },
+            {
+              "nodeId": "mime-types@2.1.24"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "body-parser@1.18.2",
+          "pkgId": "body-parser@1.18.2",
+          "deps": [
+            {
+              "nodeId": "bytes@3.0.0"
+            },
+            {
+              "nodeId": "content-type@1.0.4"
+            },
+            {
+              "nodeId": "debug@2.6.9"
+            },
+            {
+              "nodeId": "depd@1.1.2"
+            },
+            {
+              "nodeId": "http-errors@1.6.3"
+            },
+            {
+              "nodeId": "iconv-lite@0.4.19"
+            },
+            {
+              "nodeId": "on-finished@2.3.0"
+            },
+            {
+              "nodeId": "qs@6.5.1"
+            },
+            {
+              "nodeId": "raw-body@2.3.2"
+            },
+            {
+              "nodeId": "type-is@1.6.18"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "content-disposition@0.5.2",
+          "pkgId": "content-disposition@0.5.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cookie@0.3.1",
+          "pkgId": "cookie@0.3.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cookie-signature@1.0.6",
+          "pkgId": "cookie-signature@1.0.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "encodeurl@1.0.2",
+          "pkgId": "encodeurl@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "escape-html@1.0.3",
+          "pkgId": "escape-html@1.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "etag@1.8.1",
+          "pkgId": "etag@1.8.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "parseurl@1.3.2",
+          "pkgId": "parseurl@1.3.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "finalhandler@1.1.0",
+          "pkgId": "finalhandler@1.1.0",
+          "deps": [
+            {
+              "nodeId": "debug@2.6.9"
+            },
+            {
+              "nodeId": "encodeurl@1.0.2"
+            },
+            {
+              "nodeId": "escape-html@1.0.3"
+            },
+            {
+              "nodeId": "on-finished@2.3.0"
+            },
+            {
+              "nodeId": "parseurl@1.3.2"
+            },
+            {
+              "nodeId": "statuses@1.3.1"
+            },
+            {
+              "nodeId": "unpipe@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "fresh@0.5.2",
+          "pkgId": "fresh@0.5.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "merge-descriptors@1.0.1",
+          "pkgId": "merge-descriptors@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "methods@1.1.2",
+          "pkgId": "methods@1.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "path-to-regexp@0.1.7",
+          "pkgId": "path-to-regexp@0.1.7",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "forwarded@0.1.2",
+          "pkgId": "forwarded@0.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ipaddr.js@1.9.0",
+          "pkgId": "ipaddr.js@1.9.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "proxy-addr@2.0.5",
+          "pkgId": "proxy-addr@2.0.5",
+          "deps": [
+            {
+              "nodeId": "forwarded@0.1.2"
+            },
+            {
+              "nodeId": "ipaddr.js@1.9.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "range-parser@1.2.1",
+          "pkgId": "range-parser@1.2.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "safe-buffer@5.1.1",
+          "pkgId": "safe-buffer@5.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "destroy@1.0.4",
+          "pkgId": "destroy@1.0.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "mime@1.4.1",
+          "pkgId": "mime@1.4.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "send@0.16.0",
+          "pkgId": "send@0.16.0",
+          "deps": [
+            {
+              "nodeId": "debug@2.6.9"
+            },
+            {
+              "nodeId": "depd@1.1.2"
+            },
+            {
+              "nodeId": "destroy@1.0.4"
+            },
+            {
+              "nodeId": "encodeurl@1.0.2"
+            },
+            {
+              "nodeId": "escape-html@1.0.3"
+            },
+            {
+              "nodeId": "etag@1.8.1"
+            },
+            {
+              "nodeId": "fresh@0.5.2"
+            },
+            {
+              "nodeId": "http-errors@1.6.3"
+            },
+            {
+              "nodeId": "mime@1.4.1"
+            },
+            {
+              "nodeId": "ms@2.0.0"
+            },
+            {
+              "nodeId": "on-finished@2.3.0"
+            },
+            {
+              "nodeId": "range-parser@1.2.1"
+            },
+            {
+              "nodeId": "statuses@1.3.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "serve-static@1.13.0",
+          "pkgId": "serve-static@1.13.0",
+          "deps": [
+            {
+              "nodeId": "encodeurl@1.0.2"
+            },
+            {
+              "nodeId": "escape-html@1.0.3"
+            },
+            {
+              "nodeId": "parseurl@1.3.2"
+            },
+            {
+              "nodeId": "send@0.16.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "utils-merge@1.0.1",
+          "pkgId": "utils-merge@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "vary@1.1.2",
+          "pkgId": "vary@1.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "express@4.16.0",
+          "pkgId": "express@4.16.0",
+          "deps": [
+            {
+              "nodeId": "accepts@1.3.7"
+            },
+            {
+              "nodeId": "array-flatten@1.1.1"
+            },
+            {
+              "nodeId": "body-parser@1.18.2"
+            },
+            {
+              "nodeId": "content-disposition@0.5.2"
+            },
+            {
+              "nodeId": "content-type@1.0.4"
+            },
+            {
+              "nodeId": "cookie@0.3.1"
+            },
+            {
+              "nodeId": "cookie-signature@1.0.6"
+            },
+            {
+              "nodeId": "debug@2.6.9"
+            },
+            {
+              "nodeId": "depd@1.1.2"
+            },
+            {
+              "nodeId": "encodeurl@1.0.2"
+            },
+            {
+              "nodeId": "escape-html@1.0.3"
+            },
+            {
+              "nodeId": "etag@1.8.1"
+            },
+            {
+              "nodeId": "finalhandler@1.1.0"
+            },
+            {
+              "nodeId": "fresh@0.5.2"
+            },
+            {
+              "nodeId": "merge-descriptors@1.0.1"
+            },
+            {
+              "nodeId": "methods@1.1.2"
+            },
+            {
+              "nodeId": "on-finished@2.3.0"
+            },
+            {
+              "nodeId": "parseurl@1.3.2"
+            },
+            {
+              "nodeId": "path-to-regexp@0.1.7"
+            },
+            {
+              "nodeId": "proxy-addr@2.0.5"
+            },
+            {
+              "nodeId": "qs@6.5.1"
+            },
+            {
+              "nodeId": "range-parser@1.2.1"
+            },
+            {
+              "nodeId": "safe-buffer@5.1.1"
+            },
+            {
+              "nodeId": "send@0.16.0"
+            },
+            {
+              "nodeId": "serve-static@1.13.0"
+            },
+            {
+              "nodeId": "setprototypeof@1.1.0"
+            },
+            {
+              "nodeId": "statuses@1.3.1"
+            },
+            {
+              "nodeId": "type-is@1.6.18"
+            },
+            {
+              "nodeId": "utils-merge@1.0.1"
+            },
+            {
+              "nodeId": "vary@1.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "streamsearch@0.1.2",
+          "pkgId": "streamsearch@0.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "dicer@0.3.0",
+          "pkgId": "dicer@0.3.0",
+          "deps": [
+            {
+              "nodeId": "streamsearch@0.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "busboy@0.3.1",
+          "pkgId": "busboy@0.3.1",
+          "deps": [
+            {
+              "nodeId": "dicer@0.3.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "connect-busboy@0.0.2",
+          "pkgId": "connect-busboy@0.0.2",
+          "deps": [
+            {
+              "nodeId": "busboy@0.3.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "graceful-fs@4.1.15",
+          "pkgId": "graceful-fs@4.1.15",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "jsonfile@2.4.0",
+          "pkgId": "jsonfile@2.4.0",
+          "deps": [
+            {
+              "nodeId": "graceful-fs@4.1.15"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "fs.realpath@1.0.0",
+          "pkgId": "fs.realpath@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "wrappy@1.0.2",
+          "pkgId": "wrappy@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "once@1.4.0",
+          "pkgId": "once@1.4.0",
+          "deps": [
+            {
+              "nodeId": "wrappy@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "inflight@1.0.6",
+          "pkgId": "inflight@1.0.6",
+          "deps": [
+            {
+              "nodeId": "once@1.4.0"
+            },
+            {
+              "nodeId": "wrappy@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "balanced-match@1.0.0",
+          "pkgId": "balanced-match@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "concat-map@0.0.1",
+          "pkgId": "concat-map@0.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "brace-expansion@1.1.11",
+          "pkgId": "brace-expansion@1.1.11",
+          "deps": [
+            {
+              "nodeId": "balanced-match@1.0.0"
+            },
+            {
+              "nodeId": "concat-map@0.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "minimatch@3.0.4",
+          "pkgId": "minimatch@3.0.4",
+          "deps": [
+            {
+              "nodeId": "brace-expansion@1.1.11"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "path-is-absolute@1.0.1",
+          "pkgId": "path-is-absolute@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "glob@7.1.3",
+          "pkgId": "glob@7.1.3",
+          "deps": [
+            {
+              "nodeId": "fs.realpath@1.0.0"
+            },
+            {
+              "nodeId": "inflight@1.0.6"
+            },
+            {
+              "nodeId": "inherits@2.0.3"
+            },
+            {
+              "nodeId": "minimatch@3.0.4"
+            },
+            {
+              "nodeId": "once@1.4.0"
+            },
+            {
+              "nodeId": "path-is-absolute@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "rimraf@2.7.1",
+          "pkgId": "rimraf@2.7.1",
+          "deps": [
+            {
+              "nodeId": "glob@7.1.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "fs-extra@0.22.1",
+          "pkgId": "fs-extra@0.22.1",
+          "deps": [
+            {
+              "nodeId": "graceful-fs@4.1.15"
+            },
+            {
+              "nodeId": "jsonfile@2.4.0"
+            },
+            {
+              "nodeId": "rimraf@2.7.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "streamifier@0.1.1",
+          "pkgId": "streamifier@0.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "express-fileupload@0.0.5",
+          "pkgId": "express-fileupload@0.0.5",
+          "deps": [
+            {
+              "nodeId": "connect-busboy@0.0.2"
+            },
+            {
+              "nodeId": "fs-extra@0.22.1"
+            },
+            {
+              "nodeId": "streamifier@0.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ms@0.6.2",
+          "pkgId": "ms@0.6.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "humanize-ms@1.0.1",
+          "pkgId": "humanize-ms@1.0.1",
+          "deps": [
+            {
+              "nodeId": "ms@0.6.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "debug@3.1.0",
+          "pkgId": "debug@3.1.0",
+          "deps": [
+            {
+              "nodeId": "ms@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "method-override@3.0.0",
+          "pkgId": "method-override@3.0.0",
+          "deps": [
+            {
+              "nodeId": "debug@3.1.0"
+            },
+            {
+              "nodeId": "methods@1.1.2"
+            },
+            {
+              "nodeId": "parseurl@1.3.2"
+            },
+            {
+              "nodeId": "vary@1.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "moment@2.19.3",
+          "pkgId": "moment@2.19.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "safe-buffer@5.1.2",
+          "pkgId": "safe-buffer@5.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "basic-auth@2.0.1",
+          "pkgId": "basic-auth@2.0.1",
+          "deps": [
+            {
+              "nodeId": "safe-buffer@5.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "on-headers@1.0.1",
+          "pkgId": "on-headers@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "morgan@1.9.1",
+          "pkgId": "morgan@1.9.1",
+          "deps": [
+            {
+              "nodeId": "basic-auth@2.0.1"
+            },
+            {
+              "nodeId": "debug@2.6.9"
+            },
+            {
+              "nodeId": "depd@1.1.2"
+            },
+            {
+              "nodeId": "on-finished@2.3.0"
+            },
+            {
+              "nodeId": "on-headers@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ini@1.3.5",
+          "pkgId": "ini@1.3.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "proto-list@1.2.4",
+          "pkgId": "proto-list@1.2.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "config-chain@1.1.12",
+          "pkgId": "config-chain@1.1.12",
+          "deps": [
+            {
+              "nodeId": "ini@1.3.5"
+            },
+            {
+              "nodeId": "proto-list@1.2.4"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "minimist@0.0.8",
+          "pkgId": "minimist@0.0.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "mkdirp@0.5.1",
+          "pkgId": "mkdirp@0.5.1",
+          "deps": [
+            {
+              "nodeId": "minimist@0.0.8"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "abbrev@1.1.1",
+          "pkgId": "abbrev@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "nopt@3.0.6",
+          "pkgId": "nopt@3.0.6",
+          "deps": [
+            {
+              "nodeId": "abbrev@1.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "once@1.3.3",
+          "pkgId": "once@1.3.3",
+          "deps": [
+            {
+              "nodeId": "wrappy@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "os-homedir@1.0.2",
+          "pkgId": "os-homedir@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "os-tmpdir@1.0.2",
+          "pkgId": "os-tmpdir@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "osenv@0.1.5",
+          "pkgId": "osenv@0.1.5",
+          "deps": [
+            {
+              "nodeId": "os-homedir@1.0.2"
+            },
+            {
+              "nodeId": "os-tmpdir@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "semver@4.3.6",
+          "pkgId": "semver@4.3.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "uid-number@0.0.5",
+          "pkgId": "uid-number@0.0.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "npmconf@2.1.3",
+          "pkgId": "npmconf@2.1.3",
+          "deps": [
+            {
+              "nodeId": "config-chain@1.1.12"
+            },
+            {
+              "nodeId": "inherits@2.0.3"
+            },
+            {
+              "nodeId": "ini@1.3.5"
+            },
+            {
+              "nodeId": "mkdirp@0.5.1"
+            },
+            {
+              "nodeId": "nopt@3.0.6"
+            },
+            {
+              "nodeId": "once@1.3.3"
+            },
+            {
+              "nodeId": "osenv@0.1.5"
+            },
+            {
+              "nodeId": "safe-buffer@5.1.2"
+            },
+            {
+              "nodeId": "semver@4.3.6"
+            },
+            {
+              "nodeId": "uid-number@0.0.5"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "optional@0.1.4",
+          "pkgId": "optional@0.1.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash@4.17.15",
+          "pkgId": "lodash@4.17.15",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "graphlib@2.1.7",
+          "pkgId": "graphlib@2.1.7",
+          "deps": [
+            {
+              "nodeId": "lodash@4.17.15"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "object-hash@1.3.1",
+          "pkgId": "object-hash@1.3.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "semver@6.3.0",
+          "pkgId": "semver@6.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "buffer-from@1.1.1",
+          "pkgId": "buffer-from@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "source-map@0.6.1",
+          "pkgId": "source-map@0.6.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "source-map-support@0.5.13",
+          "pkgId": "source-map-support@0.5.13",
+          "deps": [
+            {
+              "nodeId": "buffer-from@1.1.1"
+            },
+            {
+              "nodeId": "source-map@0.6.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tslib@1.10.0",
+          "pkgId": "tslib@1.10.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/dep-graph@1.12.0",
+          "pkgId": "@snyk/dep-graph@1.12.0",
+          "deps": [
+            {
+              "nodeId": "graphlib@2.1.7"
+            },
+            {
+              "nodeId": "lodash@4.17.15"
+            },
+            {
+              "nodeId": "object-hash@1.3.1"
+            },
+            {
+              "nodeId": "semver@6.3.0"
+            },
+            {
+              "nodeId": "source-map-support@0.5.13"
+            },
+            {
+              "nodeId": "tslib@1.10.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/gemfile@1.2.0",
+          "pkgId": "@snyk/gemfile@1.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/events@3.0.0",
+          "pkgId": "@types/events@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/node@12.7.5",
+          "pkgId": "@types/node@12.7.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/agent-base@4.2.0",
+          "pkgId": "@types/agent-base@4.2.0",
+          "deps": [
+            {
+              "nodeId": "@types/events@3.0.0"
+            },
+            {
+              "nodeId": "@types/node@12.7.5"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/bunyan@1.8.6",
+          "pkgId": "@types/bunyan@1.8.6",
+          "deps": [
+            {
+              "nodeId": "@types/node@12.7.5"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/restify@4.3.6",
+          "pkgId": "@types/restify@4.3.6",
+          "deps": [
+            {
+              "nodeId": "@types/bunyan@1.8.6"
+            },
+            {
+              "nodeId": "@types/node@12.7.5"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-escapes@3.2.0",
+          "pkgId": "ansi-escapes@3.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "color-name@1.1.3",
+          "pkgId": "color-name@1.1.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "color-convert@1.9.3",
+          "pkgId": "color-convert@1.9.3",
+          "deps": [
+            {
+              "nodeId": "color-name@1.1.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-styles@3.2.1",
+          "pkgId": "ansi-styles@3.2.1",
+          "deps": [
+            {
+              "nodeId": "color-convert@1.9.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "escape-string-regexp@1.0.5",
+          "pkgId": "escape-string-regexp@1.0.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "has-flag@3.0.0",
+          "pkgId": "has-flag@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "supports-color@5.5.0",
+          "pkgId": "supports-color@5.5.0",
+          "deps": [
+            {
+              "nodeId": "has-flag@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "chalk@2.4.2",
+          "pkgId": "chalk@2.4.2",
+          "deps": [
+            {
+              "nodeId": "ansi-styles@3.2.1"
+            },
+            {
+              "nodeId": "escape-string-regexp@1.0.5"
+            },
+            {
+              "nodeId": "supports-color@5.5.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-obj@1.0.1",
+          "pkgId": "is-obj@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "dot-prop@4.2.0",
+          "pkgId": "dot-prop@4.2.0",
+          "deps": [
+            {
+              "nodeId": "is-obj@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pify@3.0.0",
+          "pkgId": "pify@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "make-dir@1.3.0",
+          "pkgId": "make-dir@1.3.0",
+          "deps": [
+            {
+              "nodeId": "pify@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "crypto-random-string@1.0.0",
+          "pkgId": "crypto-random-string@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "unique-string@1.0.0",
+          "pkgId": "unique-string@1.0.0",
+          "deps": [
+            {
+              "nodeId": "crypto-random-string@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "imurmurhash@0.1.4",
+          "pkgId": "imurmurhash@0.1.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "signal-exit@3.0.2",
+          "pkgId": "signal-exit@3.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "write-file-atomic@2.4.3",
+          "pkgId": "write-file-atomic@2.4.3",
+          "deps": [
+            {
+              "nodeId": "graceful-fs@4.1.15"
+            },
+            {
+              "nodeId": "imurmurhash@0.1.4"
+            },
+            {
+              "nodeId": "signal-exit@3.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xdg-basedir@3.0.0",
+          "pkgId": "xdg-basedir@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "configstore@3.1.2",
+          "pkgId": "configstore@3.1.2",
+          "deps": [
+            {
+              "nodeId": "dot-prop@4.2.0"
+            },
+            {
+              "nodeId": "graceful-fs@4.1.15"
+            },
+            {
+              "nodeId": "make-dir@1.3.0"
+            },
+            {
+              "nodeId": "unique-string@1.0.0"
+            },
+            {
+              "nodeId": "write-file-atomic@2.4.3"
+            },
+            {
+              "nodeId": "xdg-basedir@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ms@2.1.2",
+          "pkgId": "ms@2.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "debug@3.2.6",
+          "pkgId": "debug@3.2.6",
+          "deps": [
+            {
+              "nodeId": "ms@2.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "diff@4.0.1",
+          "pkgId": "diff@4.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "protocols@1.4.7",
+          "pkgId": "protocols@1.4.7",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-ssh@1.3.1",
+          "pkgId": "is-ssh@1.3.1",
+          "deps": [
+            {
+              "nodeId": "protocols@1.4.7"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "normalize-url@3.3.0",
+          "pkgId": "normalize-url@3.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "parse-path@4.0.1",
+          "pkgId": "parse-path@4.0.1",
+          "deps": [
+            {
+              "nodeId": "is-ssh@1.3.1"
+            },
+            {
+              "nodeId": "protocols@1.4.7"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "parse-url@5.0.1",
+          "pkgId": "parse-url@5.0.1",
+          "deps": [
+            {
+              "nodeId": "is-ssh@1.3.1"
+            },
+            {
+              "nodeId": "normalize-url@3.3.0"
+            },
+            {
+              "nodeId": "parse-path@4.0.1"
+            },
+            {
+              "nodeId": "protocols@1.4.7"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "git-up@4.0.1",
+          "pkgId": "git-up@4.0.1",
+          "deps": [
+            {
+              "nodeId": "is-ssh@1.3.1"
+            },
+            {
+              "nodeId": "parse-url@5.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "git-url-parse@11.1.2",
+          "pkgId": "git-url-parse@11.1.2",
+          "deps": [
+            {
+              "nodeId": "git-up@4.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "mimic-fn@1.2.0",
+          "pkgId": "mimic-fn@1.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "onetime@2.0.1",
+          "pkgId": "onetime@2.0.1",
+          "deps": [
+            {
+              "nodeId": "mimic-fn@1.2.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "restore-cursor@2.0.0",
+          "pkgId": "restore-cursor@2.0.0",
+          "deps": [
+            {
+              "nodeId": "onetime@2.0.1"
+            },
+            {
+              "nodeId": "signal-exit@3.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cli-cursor@2.1.0",
+          "pkgId": "cli-cursor@2.1.0",
+          "deps": [
+            {
+              "nodeId": "restore-cursor@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cli-width@2.2.0",
+          "pkgId": "cli-width@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "chardet@0.7.0",
+          "pkgId": "chardet@0.7.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tmp@0.0.33",
+          "pkgId": "tmp@0.0.33",
+          "deps": [
+            {
+              "nodeId": "os-tmpdir@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "external-editor@3.1.0",
+          "pkgId": "external-editor@3.1.0",
+          "deps": [
+            {
+              "nodeId": "chardet@0.7.0"
+            },
+            {
+              "nodeId": "iconv-lite@0.4.24"
+            },
+            {
+              "nodeId": "tmp@0.0.33"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "figures@2.0.0",
+          "pkgId": "figures@2.0.0",
+          "deps": [
+            {
+              "nodeId": "escape-string-regexp@1.0.5"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "mute-stream@0.0.7",
+          "pkgId": "mute-stream@0.0.7",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-promise@2.1.0",
+          "pkgId": "is-promise@2.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "run-async@2.3.0",
+          "pkgId": "run-async@2.3.0",
+          "deps": [
+            {
+              "nodeId": "is-promise@2.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "rxjs@6.5.3",
+          "pkgId": "rxjs@6.5.3",
+          "deps": [
+            {
+              "nodeId": "tslib@1.10.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-fullwidth-code-point@2.0.0",
+          "pkgId": "is-fullwidth-code-point@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-regex@3.0.0",
+          "pkgId": "ansi-regex@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "strip-ansi@4.0.0",
+          "pkgId": "strip-ansi@4.0.0",
+          "deps": [
+            {
+              "nodeId": "ansi-regex@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string-width@2.1.1",
+          "pkgId": "string-width@2.1.1",
+          "deps": [
+            {
+              "nodeId": "is-fullwidth-code-point@2.0.0"
+            },
+            {
+              "nodeId": "strip-ansi@4.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-regex@4.1.0",
+          "pkgId": "ansi-regex@4.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "strip-ansi@5.2.0",
+          "pkgId": "strip-ansi@5.2.0",
+          "deps": [
+            {
+              "nodeId": "ansi-regex@4.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "through@2.3.8",
+          "pkgId": "through@2.3.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "inquirer@6.5.2",
+          "pkgId": "inquirer@6.5.2",
+          "deps": [
+            {
+              "nodeId": "ansi-escapes@3.2.0"
+            },
+            {
+              "nodeId": "chalk@2.4.2"
+            },
+            {
+              "nodeId": "cli-cursor@2.1.0"
+            },
+            {
+              "nodeId": "cli-width@2.2.0"
+            },
+            {
+              "nodeId": "external-editor@3.1.0"
+            },
+            {
+              "nodeId": "figures@2.0.0"
+            },
+            {
+              "nodeId": "lodash@4.17.15"
+            },
+            {
+              "nodeId": "mute-stream@0.0.7"
+            },
+            {
+              "nodeId": "run-async@2.3.0"
+            },
+            {
+              "nodeId": "rxjs@6.5.3"
+            },
+            {
+              "nodeId": "string-width@2.1.1"
+            },
+            {
+              "nodeId": "strip-ansi@5.2.0"
+            },
+            {
+              "nodeId": "through@2.3.8"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-wsl@1.1.0",
+          "pkgId": "is-wsl@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "opn@5.5.0",
+          "pkgId": "opn@5.5.0",
+          "deps": [
+            {
+              "nodeId": "is-wsl@1.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "macos-release@2.3.0",
+          "pkgId": "macos-release@2.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "nice-try@1.0.5",
+          "pkgId": "nice-try@1.0.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "path-key@2.0.1",
+          "pkgId": "path-key@2.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "shebang-regex@1.0.0",
+          "pkgId": "shebang-regex@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "shebang-command@1.2.0",
+          "pkgId": "shebang-command@1.2.0",
+          "deps": [
+            {
+              "nodeId": "shebang-regex@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "isexe@2.0.0",
+          "pkgId": "isexe@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "which@1.3.1",
+          "pkgId": "which@1.3.1",
+          "deps": [
+            {
+              "nodeId": "isexe@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cross-spawn@6.0.5",
+          "pkgId": "cross-spawn@6.0.5",
+          "deps": [
+            {
+              "nodeId": "nice-try@1.0.5"
+            },
+            {
+              "nodeId": "path-key@2.0.1"
+            },
+            {
+              "nodeId": "semver@5.6.0"
+            },
+            {
+              "nodeId": "shebang-command@1.2.0"
+            },
+            {
+              "nodeId": "which@1.3.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "end-of-stream@1.4.2",
+          "pkgId": "end-of-stream@1.4.2",
+          "deps": [
+            {
+              "nodeId": "once@1.4.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pump@3.0.0",
+          "pkgId": "pump@3.0.0",
+          "deps": [
+            {
+              "nodeId": "end-of-stream@1.4.2"
+            },
+            {
+              "nodeId": "once@1.4.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "get-stream@4.1.0",
+          "pkgId": "get-stream@4.1.0",
+          "deps": [
+            {
+              "nodeId": "pump@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-stream@1.1.0",
+          "pkgId": "is-stream@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "npm-run-path@2.0.2",
+          "pkgId": "npm-run-path@2.0.2",
+          "deps": [
+            {
+              "nodeId": "path-key@2.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "p-finally@1.0.0",
+          "pkgId": "p-finally@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "strip-eof@1.0.0",
+          "pkgId": "strip-eof@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "execa@1.0.0",
+          "pkgId": "execa@1.0.0",
+          "deps": [
+            {
+              "nodeId": "cross-spawn@6.0.5"
+            },
+            {
+              "nodeId": "get-stream@4.1.0"
+            },
+            {
+              "nodeId": "is-stream@1.1.0"
+            },
+            {
+              "nodeId": "npm-run-path@2.0.2"
+            },
+            {
+              "nodeId": "p-finally@1.0.0"
+            },
+            {
+              "nodeId": "signal-exit@3.0.2"
+            },
+            {
+              "nodeId": "strip-eof@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "windows-release@3.2.0",
+          "pkgId": "windows-release@3.2.0",
+          "deps": [
+            {
+              "nodeId": "execa@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "os-name@3.1.0",
+          "pkgId": "os-name@3.1.0",
+          "deps": [
+            {
+              "nodeId": "macos-release@2.3.0"
+            },
+            {
+              "nodeId": "windows-release@3.2.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "es6-promise@4.2.8",
+          "pkgId": "es6-promise@4.2.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "es6-promisify@5.0.0",
+          "pkgId": "es6-promisify@5.0.0",
+          "deps": [
+            {
+              "nodeId": "es6-promise@4.2.8"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "agent-base@4.3.0",
+          "pkgId": "agent-base@4.3.0",
+          "deps": [
+            {
+              "nodeId": "es6-promisify@5.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "http-proxy-agent@2.1.0",
+          "pkgId": "http-proxy-agent@2.1.0",
+          "deps": [
+            {
+              "nodeId": "agent-base@4.3.0"
+            },
+            {
+              "nodeId": "debug@3.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "https-proxy-agent@2.2.2",
+          "pkgId": "https-proxy-agent@2.2.2",
+          "deps": [
+            {
+              "nodeId": "agent-base@4.3.0"
+            },
+            {
+              "nodeId": "debug@3.2.6"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pseudomap@1.0.2",
+          "pkgId": "pseudomap@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "yallist@2.1.2",
+          "pkgId": "yallist@2.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lru-cache@4.1.5",
+          "pkgId": "lru-cache@4.1.5",
+          "deps": [
+            {
+              "nodeId": "pseudomap@1.0.2"
+            },
+            {
+              "nodeId": "yallist@2.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/node@8.10.54",
+          "pkgId": "@types/node@8.10.54",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "data-uri-to-buffer@2.0.1",
+          "pkgId": "data-uri-to-buffer@2.0.1",
+          "deps": [
+            {
+              "nodeId": "@types/node@8.10.54"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "extend@3.0.2",
+          "pkgId": "extend@3.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "file-uri-to-path@1.0.0",
+          "pkgId": "file-uri-to-path@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "core-util-is@1.0.2",
+          "pkgId": "core-util-is@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "isarray@0.0.1",
+          "pkgId": "isarray@0.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string_decoder@0.10.31",
+          "pkgId": "string_decoder@0.10.31",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "readable-stream@1.1.14",
+          "pkgId": "readable-stream@1.1.14",
+          "deps": [
+            {
+              "nodeId": "core-util-is@1.0.2"
+            },
+            {
+              "nodeId": "inherits@2.0.3"
+            },
+            {
+              "nodeId": "isarray@0.0.1"
+            },
+            {
+              "nodeId": "string_decoder@0.10.31"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xregexp@2.0.0",
+          "pkgId": "xregexp@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ftp@0.3.10",
+          "pkgId": "ftp@0.3.10",
+          "deps": [
+            {
+              "nodeId": "readable-stream@1.1.14"
+            },
+            {
+              "nodeId": "xregexp@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "safe-buffer@5.2.0",
+          "pkgId": "safe-buffer@5.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string_decoder@1.3.0",
+          "pkgId": "string_decoder@1.3.0",
+          "deps": [
+            {
+              "nodeId": "safe-buffer@5.2.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "util-deprecate@1.0.2",
+          "pkgId": "util-deprecate@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "readable-stream@3.4.0",
+          "pkgId": "readable-stream@3.4.0",
+          "deps": [
+            {
+              "nodeId": "inherits@2.0.3"
+            },
+            {
+              "nodeId": "string_decoder@1.3.0"
+            },
+            {
+              "nodeId": "util-deprecate@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "get-uri@2.0.3",
+          "pkgId": "get-uri@2.0.3",
+          "deps": [
+            {
+              "nodeId": "data-uri-to-buffer@2.0.1"
+            },
+            {
+              "nodeId": "debug@4.1.0"
+            },
+            {
+              "nodeId": "extend@3.0.2"
+            },
+            {
+              "nodeId": "file-uri-to-path@1.0.0"
+            },
+            {
+              "nodeId": "ftp@0.3.10"
+            },
+            {
+              "nodeId": "readable-stream@3.4.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "co@4.6.0",
+          "pkgId": "co@4.6.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ast-types@0.13.2",
+          "pkgId": "ast-types@0.13.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "esprima@3.1.3",
+          "pkgId": "esprima@3.1.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "estraverse@4.3.0",
+          "pkgId": "estraverse@4.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "esutils@2.0.3",
+          "pkgId": "esutils@2.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "deep-is@0.1.3",
+          "pkgId": "deep-is@0.1.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "fast-levenshtein@2.0.6",
+          "pkgId": "fast-levenshtein@2.0.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "prelude-ls@1.1.2",
+          "pkgId": "prelude-ls@1.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "type-check@0.3.2",
+          "pkgId": "type-check@0.3.2",
+          "deps": [
+            {
+              "nodeId": "prelude-ls@1.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "levn@0.3.0",
+          "pkgId": "levn@0.3.0",
+          "deps": [
+            {
+              "nodeId": "prelude-ls@1.1.2"
+            },
+            {
+              "nodeId": "type-check@0.3.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "wordwrap@1.0.0",
+          "pkgId": "wordwrap@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "optionator@0.8.2",
+          "pkgId": "optionator@0.8.2",
+          "deps": [
+            {
+              "nodeId": "deep-is@0.1.3"
+            },
+            {
+              "nodeId": "fast-levenshtein@2.0.6"
+            },
+            {
+              "nodeId": "levn@0.3.0"
+            },
+            {
+              "nodeId": "prelude-ls@1.1.2"
+            },
+            {
+              "nodeId": "type-check@0.3.2"
+            },
+            {
+              "nodeId": "wordwrap@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "escodegen@1.12.0",
+          "pkgId": "escodegen@1.12.0",
+          "deps": [
+            {
+              "nodeId": "esprima@3.1.3"
+            },
+            {
+              "nodeId": "estraverse@4.3.0"
+            },
+            {
+              "nodeId": "esutils@2.0.3"
+            },
+            {
+              "nodeId": "optionator@0.8.2"
+            },
+            {
+              "nodeId": "source-map@0.6.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "degenerator@1.0.4",
+          "pkgId": "degenerator@1.0.4",
+          "deps": [
+            {
+              "nodeId": "ast-types@0.13.2"
+            },
+            {
+              "nodeId": "escodegen@1.12.0"
+            },
+            {
+              "nodeId": "esprima@3.1.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ip@1.1.5",
+          "pkgId": "ip@1.1.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "netmask@1.0.6",
+          "pkgId": "netmask@1.0.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "thunkify@2.1.2",
+          "pkgId": "thunkify@2.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pac-resolver@3.0.0",
+          "pkgId": "pac-resolver@3.0.0",
+          "deps": [
+            {
+              "nodeId": "co@4.6.0"
+            },
+            {
+              "nodeId": "degenerator@1.0.4"
+            },
+            {
+              "nodeId": "ip@1.1.5"
+            },
+            {
+              "nodeId": "netmask@1.0.6"
+            },
+            {
+              "nodeId": "thunkify@2.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "bytes@3.1.0",
+          "pkgId": "bytes@3.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "inherits@2.0.4",
+          "pkgId": "inherits@2.0.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "setprototypeof@1.1.1",
+          "pkgId": "setprototypeof@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "toidentifier@1.0.0",
+          "pkgId": "toidentifier@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "http-errors@1.7.3",
+          "pkgId": "http-errors@1.7.3",
+          "deps": [
+            {
+              "nodeId": "depd@1.1.2"
+            },
+            {
+              "nodeId": "inherits@2.0.4"
+            },
+            {
+              "nodeId": "setprototypeof@1.1.1"
+            },
+            {
+              "nodeId": "statuses@1.5.0"
+            },
+            {
+              "nodeId": "toidentifier@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "raw-body@2.4.1",
+          "pkgId": "raw-body@2.4.1",
+          "deps": [
+            {
+              "nodeId": "bytes@3.1.0"
+            },
+            {
+              "nodeId": "http-errors@1.7.3"
+            },
+            {
+              "nodeId": "iconv-lite@0.4.24"
+            },
+            {
+              "nodeId": "unpipe@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "agent-base@4.2.1",
+          "pkgId": "agent-base@4.2.1",
+          "deps": [
+            {
+              "nodeId": "es6-promisify@5.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "smart-buffer@4.0.2",
+          "pkgId": "smart-buffer@4.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "socks@2.3.2",
+          "pkgId": "socks@2.3.2",
+          "deps": [
+            {
+              "nodeId": "ip@1.1.5"
+            },
+            {
+              "nodeId": "smart-buffer@4.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "socks-proxy-agent@4.0.2",
+          "pkgId": "socks-proxy-agent@4.0.2",
+          "deps": [
+            {
+              "nodeId": "agent-base@4.2.1"
+            },
+            {
+              "nodeId": "socks@2.3.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pac-proxy-agent@3.0.0",
+          "pkgId": "pac-proxy-agent@3.0.0",
+          "deps": [
+            {
+              "nodeId": "agent-base@4.3.0"
+            },
+            {
+              "nodeId": "debug@3.2.6"
+            },
+            {
+              "nodeId": "get-uri@2.0.3"
+            },
+            {
+              "nodeId": "http-proxy-agent@2.1.0"
+            },
+            {
+              "nodeId": "https-proxy-agent@2.2.2"
+            },
+            {
+              "nodeId": "pac-resolver@3.0.0"
+            },
+            {
+              "nodeId": "raw-body@2.4.1"
+            },
+            {
+              "nodeId": "socks-proxy-agent@4.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "proxy-from-env@1.0.0",
+          "pkgId": "proxy-from-env@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "proxy-agent@3.1.0",
+          "pkgId": "proxy-agent@3.1.0",
+          "deps": [
+            {
+              "nodeId": "agent-base@4.3.0"
+            },
+            {
+              "nodeId": "debug@3.2.6"
+            },
+            {
+              "nodeId": "http-proxy-agent@2.1.0"
+            },
+            {
+              "nodeId": "https-proxy-agent@2.2.2"
+            },
+            {
+              "nodeId": "lru-cache@4.1.5"
+            },
+            {
+              "nodeId": "pac-proxy-agent@3.0.0"
+            },
+            {
+              "nodeId": "proxy-from-env@1.0.0"
+            },
+            {
+              "nodeId": "socks-proxy-agent@4.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "async@1.5.2",
+          "pkgId": "async@1.5.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "secure-keys@1.0.0",
+          "pkgId": "secure-keys@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "camelcase@2.1.1",
+          "pkgId": "camelcase@2.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "code-point-at@1.1.0",
+          "pkgId": "code-point-at@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "number-is-nan@1.0.1",
+          "pkgId": "number-is-nan@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-fullwidth-code-point@1.0.0",
+          "pkgId": "is-fullwidth-code-point@1.0.0",
+          "deps": [
+            {
+              "nodeId": "number-is-nan@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-regex@2.1.1",
+          "pkgId": "ansi-regex@2.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "strip-ansi@3.0.1",
+          "pkgId": "strip-ansi@3.0.1",
+          "deps": [
+            {
+              "nodeId": "ansi-regex@2.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string-width@1.0.2",
+          "pkgId": "string-width@1.0.2",
+          "deps": [
+            {
+              "nodeId": "code-point-at@1.1.0"
+            },
+            {
+              "nodeId": "is-fullwidth-code-point@1.0.0"
+            },
+            {
+              "nodeId": "strip-ansi@3.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "wrap-ansi@2.1.0",
+          "pkgId": "wrap-ansi@2.1.0",
+          "deps": [
+            {
+              "nodeId": "string-width@1.0.2"
+            },
+            {
+              "nodeId": "strip-ansi@3.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cliui@3.2.0",
+          "pkgId": "cliui@3.2.0",
+          "deps": [
+            {
+              "nodeId": "string-width@1.0.2"
+            },
+            {
+              "nodeId": "strip-ansi@3.0.1"
+            },
+            {
+              "nodeId": "wrap-ansi@2.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "decamelize@1.2.0",
+          "pkgId": "decamelize@1.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "invert-kv@1.0.0",
+          "pkgId": "invert-kv@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lcid@1.0.0",
+          "pkgId": "lcid@1.0.0",
+          "deps": [
+            {
+              "nodeId": "invert-kv@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "os-locale@1.4.0",
+          "pkgId": "os-locale@1.4.0",
+          "deps": [
+            {
+              "nodeId": "lcid@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "window-size@0.1.4",
+          "pkgId": "window-size@0.1.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "y18n@3.2.1",
+          "pkgId": "y18n@3.2.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "yargs@3.32.0",
+          "pkgId": "yargs@3.32.0",
+          "deps": [
+            {
+              "nodeId": "camelcase@2.1.1"
+            },
+            {
+              "nodeId": "cliui@3.2.0"
+            },
+            {
+              "nodeId": "decamelize@1.2.0"
+            },
+            {
+              "nodeId": "os-locale@1.4.0"
+            },
+            {
+              "nodeId": "string-width@1.0.2"
+            },
+            {
+              "nodeId": "window-size@0.1.4"
+            },
+            {
+              "nodeId": "y18n@3.2.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "nconf@0.10.0",
+          "pkgId": "nconf@0.10.0",
+          "deps": [
+            {
+              "nodeId": "async@1.5.2"
+            },
+            {
+              "nodeId": "ini@1.3.5"
+            },
+            {
+              "nodeId": "secure-keys@1.0.0"
+            },
+            {
+              "nodeId": "yargs@3.32.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-config@2.2.3",
+          "pkgId": "snyk-config@2.2.3",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.6"
+            },
+            {
+              "nodeId": "lodash@4.17.15"
+            },
+            {
+              "nodeId": "nconf@0.10.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "debug@4.1.1",
+          "pkgId": "debug@4.1.1",
+          "deps": [
+            {
+              "nodeId": "ms@2.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "vscode-languageserver-types@3.14.0",
+          "pkgId": "vscode-languageserver-types@3.14.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "dockerfile-ast@0.0.16",
+          "pkgId": "dockerfile-ast@0.0.16",
+          "deps": [
+            {
+              "nodeId": "vscode-languageserver-types@3.14.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-docker-plugin@1.29.1",
+          "pkgId": "snyk-docker-plugin@1.29.1",
+          "deps": [
+            {
+              "nodeId": "debug@4.1.1"
+            },
+            {
+              "nodeId": "dockerfile-ast@0.0.16"
+            },
+            {
+              "nodeId": "semver@6.3.0"
+            },
+            {
+              "nodeId": "tslib@1.10.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "toml@3.0.0",
+          "pkgId": "toml@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-go-parser@1.3.1",
+          "pkgId": "snyk-go-parser@1.3.1",
+          "deps": [
+            {
+              "nodeId": "toml@3.0.0"
+            },
+            {
+              "nodeId": "tslib@1.10.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-go-plugin@1.11.0",
+          "pkgId": "snyk-go-plugin@1.11.0",
+          "deps": [
+            {
+              "nodeId": "debug@4.1.1"
+            },
+            {
+              "nodeId": "graphlib@2.1.7"
+            },
+            {
+              "nodeId": "snyk-go-parser@1.3.1"
+            },
+            {
+              "nodeId": "tmp@0.0.33"
+            },
+            {
+              "nodeId": "tslib@1.10.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/cli-interface@2.1.0",
+          "pkgId": "@snyk/cli-interface@2.1.0",
+          "deps": [
+            {
+              "nodeId": "tslib@1.10.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/debug@4.1.5",
+          "pkgId": "@types/debug@4.1.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "for-in@1.0.2",
+          "pkgId": "for-in@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "for-own@1.0.0",
+          "pkgId": "for-own@1.0.0",
+          "deps": [
+            {
+              "nodeId": "for-in@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "isobject@3.0.1",
+          "pkgId": "isobject@3.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-plain-object@2.0.4",
+          "pkgId": "is-plain-object@2.0.4",
+          "deps": [
+            {
+              "nodeId": "isobject@3.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-buffer@1.1.6",
+          "pkgId": "is-buffer@1.1.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "kind-of@3.2.2",
+          "pkgId": "kind-of@3.2.2",
+          "deps": [
+            {
+              "nodeId": "is-buffer@1.1.6"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-extendable@0.1.1",
+          "pkgId": "is-extendable@0.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "kind-of@2.0.1",
+          "pkgId": "kind-of@2.0.1",
+          "deps": [
+            {
+              "nodeId": "is-buffer@1.1.6"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lazy-cache@0.2.7",
+          "pkgId": "lazy-cache@0.2.7",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "for-in@0.1.8",
+          "pkgId": "for-in@0.1.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "mixin-object@2.0.1",
+          "pkgId": "mixin-object@2.0.1",
+          "deps": [
+            {
+              "nodeId": "for-in@0.1.8"
+            },
+            {
+              "nodeId": "is-extendable@0.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "shallow-clone@0.1.2",
+          "pkgId": "shallow-clone@0.1.2",
+          "deps": [
+            {
+              "nodeId": "is-extendable@0.1.1"
+            },
+            {
+              "nodeId": "kind-of@2.0.1"
+            },
+            {
+              "nodeId": "lazy-cache@0.2.7"
+            },
+            {
+              "nodeId": "mixin-object@2.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "clone-deep@0.3.0",
+          "pkgId": "clone-deep@0.3.0",
+          "deps": [
+            {
+              "nodeId": "for-own@1.0.0"
+            },
+            {
+              "nodeId": "is-plain-object@2.0.4"
+            },
+            {
+              "nodeId": "kind-of@3.2.2"
+            },
+            {
+              "nodeId": "shallow-clone@0.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-gradle-plugin@3.1.0",
+          "pkgId": "snyk-gradle-plugin@3.1.0",
+          "deps": [
+            {
+              "nodeId": "@snyk/cli-interface@2.1.0"
+            },
+            {
+              "nodeId": "@types/debug@4.1.5"
+            },
+            {
+              "nodeId": "chalk@2.4.2"
+            },
+            {
+              "nodeId": "clone-deep@0.3.0"
+            },
+            {
+              "nodeId": "debug@4.1.1"
+            },
+            {
+              "nodeId": "tmp@0.0.33"
+            },
+            {
+              "nodeId": "tslib@1.10.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "hosted-git-info@2.8.4",
+          "pkgId": "hosted-git-info@2.8.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-module@1.9.1",
+          "pkgId": "snyk-module@1.9.1",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.6"
+            },
+            {
+              "nodeId": "hosted-git-info@2.8.4"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tslib@1.9.3",
+          "pkgId": "tslib@1.9.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-mvn-plugin@2.4.0",
+          "pkgId": "snyk-mvn-plugin@2.4.0",
+          "deps": [
+            {
+              "nodeId": "lodash@4.17.15"
+            },
+            {
+              "nodeId": "tslib@1.9.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@yarnpkg/lockfile@1.1.0",
+          "pkgId": "@yarnpkg/lockfile@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "uuid@3.3.3",
+          "pkgId": "uuid@3.3.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-nodejs-lockfile-parser@1.16.0",
+          "pkgId": "snyk-nodejs-lockfile-parser@1.16.0",
+          "deps": [
+            {
+              "nodeId": "@yarnpkg/lockfile@1.1.0"
+            },
+            {
+              "nodeId": "graphlib@2.1.7"
+            },
+            {
+              "nodeId": "lodash@4.17.15"
+            },
+            {
+              "nodeId": "source-map-support@0.5.13"
+            },
+            {
+              "nodeId": "tslib@1.10.0"
+            },
+            {
+              "nodeId": "uuid@3.3.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/xml2js@0.4.3",
+          "pkgId": "@types/xml2js@0.4.3",
+          "deps": [
+            {
+              "nodeId": "@types/events@3.0.0"
+            },
+            {
+              "nodeId": "@types/node@12.7.5"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xmlbuilder@9.0.7",
+          "pkgId": "xmlbuilder@9.0.7",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xml2js@0.4.19",
+          "pkgId": "xml2js@0.4.19",
+          "deps": [
+            {
+              "nodeId": "sax@1.2.4"
+            },
+            {
+              "nodeId": "xmlbuilder@9.0.7"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "dotnet-deps-parser@4.5.0",
+          "pkgId": "dotnet-deps-parser@4.5.0",
+          "deps": [
+            {
+              "nodeId": "@types/xml2js@0.4.3"
+            },
+            {
+              "nodeId": "lodash@4.17.15"
+            },
+            {
+              "nodeId": "source-map-support@0.5.13"
+            },
+            {
+              "nodeId": "tslib@1.10.0"
+            },
+            {
+              "nodeId": "xml2js@0.4.19"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "immediate@3.0.6",
+          "pkgId": "immediate@3.0.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lie@3.3.0",
+          "pkgId": "lie@3.3.0",
+          "deps": [
+            {
+              "nodeId": "immediate@3.0.6"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pako@1.0.10",
+          "pkgId": "pako@1.0.10",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "isarray@1.0.0",
+          "pkgId": "isarray@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "process-nextick-args@2.0.0",
+          "pkgId": "process-nextick-args@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string_decoder@1.1.1",
+          "pkgId": "string_decoder@1.1.1",
+          "deps": [
+            {
+              "nodeId": "safe-buffer@5.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "readable-stream@2.3.6",
+          "pkgId": "readable-stream@2.3.6",
+          "deps": [
+            {
+              "nodeId": "core-util-is@1.0.2"
+            },
+            {
+              "nodeId": "inherits@2.0.3"
+            },
+            {
+              "nodeId": "isarray@1.0.0"
+            },
+            {
+              "nodeId": "process-nextick-args@2.0.0"
+            },
+            {
+              "nodeId": "safe-buffer@5.1.2"
+            },
+            {
+              "nodeId": "string_decoder@1.1.1"
+            },
+            {
+              "nodeId": "util-deprecate@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "set-immediate-shim@1.0.1",
+          "pkgId": "set-immediate-shim@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "jszip@3.2.2",
+          "pkgId": "jszip@3.2.2",
+          "deps": [
+            {
+              "nodeId": "lie@3.3.0"
+            },
+            {
+              "nodeId": "pako@1.0.10"
+            },
+            {
+              "nodeId": "readable-stream@2.3.6"
+            },
+            {
+              "nodeId": "set-immediate-shim@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-paket-parser@1.5.0",
+          "pkgId": "snyk-paket-parser@1.5.0",
+          "deps": [
+            {
+              "nodeId": "tslib@1.10.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "object-keys@1.1.1",
+          "pkgId": "object-keys@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "define-properties@1.1.3",
+          "pkgId": "define-properties@1.1.3",
+          "deps": [
+            {
+              "nodeId": "object-keys@1.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-callable@1.1.4",
+          "pkgId": "is-callable@1.1.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-date-object@1.0.1",
+          "pkgId": "is-date-object@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "has-symbols@1.0.0",
+          "pkgId": "has-symbols@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-symbol@1.0.2",
+          "pkgId": "is-symbol@1.0.2",
+          "deps": [
+            {
+              "nodeId": "has-symbols@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "es-to-primitive@1.2.0",
+          "pkgId": "es-to-primitive@1.2.0",
+          "deps": [
+            {
+              "nodeId": "is-callable@1.1.4"
+            },
+            {
+              "nodeId": "is-date-object@1.0.1"
+            },
+            {
+              "nodeId": "is-symbol@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "function-bind@1.1.1",
+          "pkgId": "function-bind@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "has@1.0.3",
+          "pkgId": "has@1.0.3",
+          "deps": [
+            {
+              "nodeId": "function-bind@1.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-regex@1.0.4",
+          "pkgId": "is-regex@1.0.4",
+          "deps": [
+            {
+              "nodeId": "has@1.0.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "object-inspect@1.6.0",
+          "pkgId": "object-inspect@1.6.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string.prototype.trimleft@2.1.0",
+          "pkgId": "string.prototype.trimleft@2.1.0",
+          "deps": [
+            {
+              "nodeId": "define-properties@1.1.3"
+            },
+            {
+              "nodeId": "function-bind@1.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string.prototype.trimright@2.1.0",
+          "pkgId": "string.prototype.trimright@2.1.0",
+          "deps": [
+            {
+              "nodeId": "define-properties@1.1.3"
+            },
+            {
+              "nodeId": "function-bind@1.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "es-abstract@1.14.2",
+          "pkgId": "es-abstract@1.14.2",
+          "deps": [
+            {
+              "nodeId": "es-to-primitive@1.2.0"
+            },
+            {
+              "nodeId": "function-bind@1.1.1"
+            },
+            {
+              "nodeId": "has@1.0.3"
+            },
+            {
+              "nodeId": "has-symbols@1.0.0"
+            },
+            {
+              "nodeId": "is-callable@1.1.4"
+            },
+            {
+              "nodeId": "is-regex@1.0.4"
+            },
+            {
+              "nodeId": "object-inspect@1.6.0"
+            },
+            {
+              "nodeId": "object-keys@1.1.1"
+            },
+            {
+              "nodeId": "string.prototype.trimleft@2.1.0"
+            },
+            {
+              "nodeId": "string.prototype.trimright@2.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "object.getownpropertydescriptors@2.0.3",
+          "pkgId": "object.getownpropertydescriptors@2.0.3",
+          "deps": [
+            {
+              "nodeId": "define-properties@1.1.3"
+            },
+            {
+              "nodeId": "es-abstract@1.14.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "util.promisify@1.0.0",
+          "pkgId": "util.promisify@1.0.0",
+          "deps": [
+            {
+              "nodeId": "define-properties@1.1.3"
+            },
+            {
+              "nodeId": "object.getownpropertydescriptors@2.0.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xmlbuilder@11.0.1",
+          "pkgId": "xmlbuilder@11.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xml2js@0.4.22",
+          "pkgId": "xml2js@0.4.22",
+          "deps": [
+            {
+              "nodeId": "sax@1.2.4"
+            },
+            {
+              "nodeId": "util.promisify@1.0.0"
+            },
+            {
+              "nodeId": "xmlbuilder@11.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-nuget-plugin@1.12.1",
+          "pkgId": "snyk-nuget-plugin@1.12.1",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.6"
+            },
+            {
+              "nodeId": "dotnet-deps-parser@4.5.0"
+            },
+            {
+              "nodeId": "jszip@3.2.2"
+            },
+            {
+              "nodeId": "lodash@4.17.15"
+            },
+            {
+              "nodeId": "snyk-paket-parser@1.5.0"
+            },
+            {
+              "nodeId": "tslib@1.10.0"
+            },
+            {
+              "nodeId": "xml2js@0.4.22"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/composer-lockfile-parser@1.0.3",
+          "pkgId": "@snyk/composer-lockfile-parser@1.0.3",
+          "deps": [
+            {
+              "nodeId": "lodash@4.17.15"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-php-plugin@1.6.4",
+          "pkgId": "snyk-php-plugin@1.6.4",
+          "deps": [
+            {
+              "nodeId": "@snyk/composer-lockfile-parser@1.0.3"
+            },
+            {
+              "nodeId": "tslib@1.9.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "email-validator@2.0.4",
+          "pkgId": "email-validator@2.0.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.clonedeep@4.5.0",
+          "pkgId": "lodash.clonedeep@4.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "asap@2.0.6",
+          "pkgId": "asap@2.0.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "promise@7.3.1",
+          "pkgId": "promise@7.3.1",
+          "deps": [
+            {
+              "nodeId": "asap@2.0.6"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "then-fs@2.0.0",
+          "pkgId": "then-fs@2.0.0",
+          "deps": [
+            {
+              "nodeId": "promise@7.3.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-resolve@1.0.1",
+          "pkgId": "snyk-resolve@1.0.1",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.6"
+            },
+            {
+              "nodeId": "then-fs@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-try-require@1.3.1",
+          "pkgId": "snyk-try-require@1.3.1",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.6"
+            },
+            {
+              "nodeId": "lodash.clonedeep@4.5.0"
+            },
+            {
+              "nodeId": "lru-cache@4.1.5"
+            },
+            {
+              "nodeId": "then-fs@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-policy@1.13.5",
+          "pkgId": "snyk-policy@1.13.5",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.6"
+            },
+            {
+              "nodeId": "email-validator@2.0.4"
+            },
+            {
+              "nodeId": "js-yaml@3.13.1"
+            },
+            {
+              "nodeId": "lodash.clonedeep@4.5.0"
+            },
+            {
+              "nodeId": "semver@6.3.0"
+            },
+            {
+              "nodeId": "snyk-module@1.9.1"
+            },
+            {
+              "nodeId": "snyk-resolve@1.0.1"
+            },
+            {
+              "nodeId": "snyk-try-require@1.3.1"
+            },
+            {
+              "nodeId": "then-fs@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-python-plugin@1.13.2",
+          "pkgId": "snyk-python-plugin@1.13.2",
+          "deps": [
+            {
+              "nodeId": "@snyk/cli-interface@2.1.0"
+            },
+            {
+              "nodeId": "tmp@0.0.33"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/node@6.14.7",
+          "pkgId": "@types/node@6.14.7",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/semver@5.5.0",
+          "pkgId": "@types/semver@5.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansicolors@0.3.2",
+          "pkgId": "ansicolors@0.3.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.assign@4.2.0",
+          "pkgId": "lodash.assign@4.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.assignin@4.2.0",
+          "pkgId": "lodash.assignin@4.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.clone@4.5.0",
+          "pkgId": "lodash.clone@4.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.flatten@4.4.0",
+          "pkgId": "lodash.flatten@4.4.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.get@4.4.2",
+          "pkgId": "lodash.get@4.4.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.set@4.3.2",
+          "pkgId": "lodash.set@4.3.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "archy@1.0.0",
+          "pkgId": "archy@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-tree@1.0.0",
+          "pkgId": "snyk-tree@1.0.0",
+          "deps": [
+            {
+              "nodeId": "archy@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-resolve-deps@4.4.0",
+          "pkgId": "snyk-resolve-deps@4.4.0",
+          "deps": [
+            {
+              "nodeId": "@types/node@6.14.7"
+            },
+            {
+              "nodeId": "@types/semver@5.5.0"
+            },
+            {
+              "nodeId": "ansicolors@0.3.2"
+            },
+            {
+              "nodeId": "debug@3.2.6"
+            },
+            {
+              "nodeId": "lodash.assign@4.2.0"
+            },
+            {
+              "nodeId": "lodash.assignin@4.2.0"
+            },
+            {
+              "nodeId": "lodash.clone@4.5.0"
+            },
+            {
+              "nodeId": "lodash.flatten@4.4.0"
+            },
+            {
+              "nodeId": "lodash.get@4.4.2"
+            },
+            {
+              "nodeId": "lodash.set@4.3.2"
+            },
+            {
+              "nodeId": "lru-cache@4.1.5"
+            },
+            {
+              "nodeId": "semver@5.6.0"
+            },
+            {
+              "nodeId": "snyk-module@1.9.1"
+            },
+            {
+              "nodeId": "snyk-resolve@1.0.1"
+            },
+            {
+              "nodeId": "snyk-tree@1.0.0"
+            },
+            {
+              "nodeId": "snyk-try-require@1.3.1"
+            },
+            {
+              "nodeId": "then-fs@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tmp@0.1.0",
+          "pkgId": "tmp@0.1.0",
+          "deps": [
+            {
+              "nodeId": "rimraf@2.7.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tree-kill@1.2.1",
+          "pkgId": "tree-kill@1.2.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-sbt-plugin@2.8.0",
+          "pkgId": "snyk-sbt-plugin@2.8.0",
+          "deps": [
+            {
+              "nodeId": "semver@6.3.0"
+            },
+            {
+              "nodeId": "tmp@0.1.0"
+            },
+            {
+              "nodeId": "tree-kill@1.2.1"
+            },
+            {
+              "nodeId": "tslib@1.10.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "temp-dir@1.0.0",
+          "pkgId": "temp-dir@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tempfile@2.0.0",
+          "pkgId": "tempfile@2.0.0",
+          "deps": [
+            {
+              "nodeId": "temp-dir@1.0.0"
+            },
+            {
+              "nodeId": "uuid@3.3.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-align@2.0.0",
+          "pkgId": "ansi-align@2.0.0",
+          "deps": [
+            {
+              "nodeId": "string-width@2.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "camelcase@4.1.0",
+          "pkgId": "camelcase@4.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cli-boxes@1.0.0",
+          "pkgId": "cli-boxes@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cross-spawn@5.1.0",
+          "pkgId": "cross-spawn@5.1.0",
+          "deps": [
+            {
+              "nodeId": "lru-cache@4.1.5"
+            },
+            {
+              "nodeId": "shebang-command@1.2.0"
+            },
+            {
+              "nodeId": "which@1.3.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "get-stream@3.0.0",
+          "pkgId": "get-stream@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "execa@0.7.0",
+          "pkgId": "execa@0.7.0",
+          "deps": [
+            {
+              "nodeId": "cross-spawn@5.1.0"
+            },
+            {
+              "nodeId": "get-stream@3.0.0"
+            },
+            {
+              "nodeId": "is-stream@1.1.0"
+            },
+            {
+              "nodeId": "npm-run-path@2.0.2"
+            },
+            {
+              "nodeId": "p-finally@1.0.0"
+            },
+            {
+              "nodeId": "signal-exit@3.0.2"
+            },
+            {
+              "nodeId": "strip-eof@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "term-size@1.2.0",
+          "pkgId": "term-size@1.2.0",
+          "deps": [
+            {
+              "nodeId": "execa@0.7.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "widest-line@2.0.1",
+          "pkgId": "widest-line@2.0.1",
+          "deps": [
+            {
+              "nodeId": "string-width@2.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "boxen@1.3.0",
+          "pkgId": "boxen@1.3.0",
+          "deps": [
+            {
+              "nodeId": "ansi-align@2.0.0"
+            },
+            {
+              "nodeId": "camelcase@4.1.0"
+            },
+            {
+              "nodeId": "chalk@2.4.2"
+            },
+            {
+              "nodeId": "cli-boxes@1.0.0"
+            },
+            {
+              "nodeId": "string-width@2.1.1"
+            },
+            {
+              "nodeId": "term-size@1.2.0"
+            },
+            {
+              "nodeId": "widest-line@2.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "import-lazy@2.1.0",
+          "pkgId": "import-lazy@2.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ci-info@1.6.0",
+          "pkgId": "ci-info@1.6.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-ci@1.2.1",
+          "pkgId": "is-ci@1.2.1",
+          "deps": [
+            {
+              "nodeId": "ci-info@1.6.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "global-dirs@0.1.1",
+          "pkgId": "global-dirs@0.1.1",
+          "deps": [
+            {
+              "nodeId": "ini@1.3.5"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "path-is-inside@1.0.2",
+          "pkgId": "path-is-inside@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-path-inside@1.0.1",
+          "pkgId": "is-path-inside@1.0.1",
+          "deps": [
+            {
+              "nodeId": "path-is-inside@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-installed-globally@0.1.0",
+          "pkgId": "is-installed-globally@0.1.0",
+          "deps": [
+            {
+              "nodeId": "global-dirs@0.1.1"
+            },
+            {
+              "nodeId": "is-path-inside@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-npm@1.0.0",
+          "pkgId": "is-npm@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "capture-stack-trace@1.0.1",
+          "pkgId": "capture-stack-trace@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "create-error-class@3.0.2",
+          "pkgId": "create-error-class@3.0.2",
+          "deps": [
+            {
+              "nodeId": "capture-stack-trace@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "duplexer3@0.1.4",
+          "pkgId": "duplexer3@0.1.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-redirect@1.0.0",
+          "pkgId": "is-redirect@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-retry-allowed@1.2.0",
+          "pkgId": "is-retry-allowed@1.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lowercase-keys@1.0.1",
+          "pkgId": "lowercase-keys@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "timed-out@4.0.1",
+          "pkgId": "timed-out@4.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "unzip-response@2.0.1",
+          "pkgId": "unzip-response@2.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "prepend-http@1.0.4",
+          "pkgId": "prepend-http@1.0.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "url-parse-lax@1.0.0",
+          "pkgId": "url-parse-lax@1.0.0",
+          "deps": [
+            {
+              "nodeId": "prepend-http@1.0.4"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "got@6.7.1",
+          "pkgId": "got@6.7.1",
+          "deps": [
+            {
+              "nodeId": "create-error-class@3.0.2"
+            },
+            {
+              "nodeId": "duplexer3@0.1.4"
+            },
+            {
+              "nodeId": "get-stream@3.0.0"
+            },
+            {
+              "nodeId": "is-redirect@1.0.0"
+            },
+            {
+              "nodeId": "is-retry-allowed@1.2.0"
+            },
+            {
+              "nodeId": "is-stream@1.1.0"
+            },
+            {
+              "nodeId": "lowercase-keys@1.0.1"
+            },
+            {
+              "nodeId": "safe-buffer@5.1.2"
+            },
+            {
+              "nodeId": "timed-out@4.0.1"
+            },
+            {
+              "nodeId": "unzip-response@2.0.1"
+            },
+            {
+              "nodeId": "url-parse-lax@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "deep-extend@0.6.0",
+          "pkgId": "deep-extend@0.6.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "minimist@1.2.0",
+          "pkgId": "minimist@1.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "strip-json-comments@2.0.1",
+          "pkgId": "strip-json-comments@2.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "rc@1.2.8",
+          "pkgId": "rc@1.2.8",
+          "deps": [
+            {
+              "nodeId": "deep-extend@0.6.0"
+            },
+            {
+              "nodeId": "ini@1.3.5"
+            },
+            {
+              "nodeId": "minimist@1.2.0"
+            },
+            {
+              "nodeId": "strip-json-comments@2.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "registry-auth-token@3.4.0",
+          "pkgId": "registry-auth-token@3.4.0",
+          "deps": [
+            {
+              "nodeId": "rc@1.2.8"
+            },
+            {
+              "nodeId": "safe-buffer@5.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "registry-url@3.1.0",
+          "pkgId": "registry-url@3.1.0",
+          "deps": [
+            {
+              "nodeId": "rc@1.2.8"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "package-json@4.0.1",
+          "pkgId": "package-json@4.0.1",
+          "deps": [
+            {
+              "nodeId": "got@6.7.1"
+            },
+            {
+              "nodeId": "registry-auth-token@3.4.0"
+            },
+            {
+              "nodeId": "registry-url@3.1.0"
+            },
+            {
+              "nodeId": "semver@5.6.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "latest-version@3.1.0",
+          "pkgId": "latest-version@3.1.0",
+          "deps": [
+            {
+              "nodeId": "package-json@4.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "semver-diff@2.1.0",
+          "pkgId": "semver-diff@2.1.0",
+          "deps": [
+            {
+              "nodeId": "semver@5.6.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "update-notifier@2.5.0",
+          "pkgId": "update-notifier@2.5.0",
+          "deps": [
+            {
+              "nodeId": "boxen@1.3.0"
+            },
+            {
+              "nodeId": "chalk@2.4.2"
+            },
+            {
+              "nodeId": "configstore@3.1.2"
+            },
+            {
+              "nodeId": "import-lazy@2.1.0"
+            },
+            {
+              "nodeId": "is-ci@1.2.1"
+            },
+            {
+              "nodeId": "is-installed-globally@0.1.0"
+            },
+            {
+              "nodeId": "is-npm@1.0.0"
+            },
+            {
+              "nodeId": "latest-version@3.1.0"
+            },
+            {
+              "nodeId": "semver-diff@2.1.0"
+            },
+            {
+              "nodeId": "xdg-basedir@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "emoji-regex@7.0.3",
+          "pkgId": "emoji-regex@7.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string-width@3.1.0",
+          "pkgId": "string-width@3.1.0",
+          "deps": [
+            {
+              "nodeId": "emoji-regex@7.0.3"
+            },
+            {
+              "nodeId": "is-fullwidth-code-point@2.0.0"
+            },
+            {
+              "nodeId": "strip-ansi@5.2.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "wrap-ansi@5.1.0",
+          "pkgId": "wrap-ansi@5.1.0",
+          "deps": [
+            {
+              "nodeId": "ansi-styles@3.2.1"
+            },
+            {
+              "nodeId": "string-width@3.1.0"
+            },
+            {
+              "nodeId": "strip-ansi@5.2.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk@1.228.3",
+          "pkgId": "snyk@1.228.3",
+          "deps": [
+            {
+              "nodeId": "@snyk/dep-graph@1.12.0"
+            },
+            {
+              "nodeId": "@snyk/gemfile@1.2.0"
+            },
+            {
+              "nodeId": "@types/agent-base@4.2.0"
+            },
+            {
+              "nodeId": "@types/restify@4.3.6"
+            },
+            {
+              "nodeId": "abbrev@1.1.1"
+            },
+            {
+              "nodeId": "ansi-escapes@3.2.0"
+            },
+            {
+              "nodeId": "chalk@2.4.2"
+            },
+            {
+              "nodeId": "configstore@3.1.2"
+            },
+            {
+              "nodeId": "debug@3.2.6"
+            },
+            {
+              "nodeId": "diff@4.0.1"
+            },
+            {
+              "nodeId": "git-url-parse@11.1.2"
+            },
+            {
+              "nodeId": "glob@7.1.3"
+            },
+            {
+              "nodeId": "inquirer@6.5.2"
+            },
+            {
+              "nodeId": "lodash@4.17.15"
+            },
+            {
+              "nodeId": "needle@2.2.4"
+            },
+            {
+              "nodeId": "opn@5.5.0"
+            },
+            {
+              "nodeId": "os-name@3.1.0"
+            },
+            {
+              "nodeId": "proxy-agent@3.1.0"
+            },
+            {
+              "nodeId": "proxy-from-env@1.0.0"
+            },
+            {
+              "nodeId": "semver@6.3.0"
+            },
+            {
+              "nodeId": "snyk-config@2.2.3"
+            },
+            {
+              "nodeId": "snyk-docker-plugin@1.29.1"
+            },
+            {
+              "nodeId": "snyk-go-plugin@1.11.0"
+            },
+            {
+              "nodeId": "snyk-gradle-plugin@3.1.0"
+            },
+            {
+              "nodeId": "snyk-module@1.9.1"
+            },
+            {
+              "nodeId": "snyk-mvn-plugin@2.4.0"
+            },
+            {
+              "nodeId": "snyk-nodejs-lockfile-parser@1.16.0"
+            },
+            {
+              "nodeId": "snyk-nuget-plugin@1.12.1"
+            },
+            {
+              "nodeId": "snyk-php-plugin@1.6.4"
+            },
+            {
+              "nodeId": "snyk-policy@1.13.5"
+            },
+            {
+              "nodeId": "snyk-python-plugin@1.13.2"
+            },
+            {
+              "nodeId": "snyk-resolve@1.0.1"
+            },
+            {
+              "nodeId": "snyk-resolve-deps@4.4.0"
+            },
+            {
+              "nodeId": "snyk-sbt-plugin@2.8.0"
+            },
+            {
+              "nodeId": "snyk-tree@1.0.0"
+            },
+            {
+              "nodeId": "snyk-try-require@1.3.1"
+            },
+            {
+              "nodeId": "source-map-support@0.5.13"
+            },
+            {
+              "nodeId": "strip-ansi@5.2.0"
+            },
+            {
+              "nodeId": "tempfile@2.0.0"
+            },
+            {
+              "nodeId": "then-fs@2.0.0"
+            },
+            {
+              "nodeId": "update-notifier@2.5.0"
+            },
+            {
+              "nodeId": "uuid@3.3.3"
+            },
+            {
+              "nodeId": "wrap-ansi@5.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "async-cache@1.1.0",
+          "pkgId": "async-cache@1.1.0",
+          "deps": [
+            {
+              "nodeId": "lru-cache@4.1.5"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "bl@1.2.2",
+          "pkgId": "bl@1.2.2",
+          "deps": [
+            {
+              "nodeId": "readable-stream@2.3.6"
+            },
+            {
+              "nodeId": "safe-buffer@5.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "fd@0.0.3",
+          "pkgId": "fd@0.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "st@1.2.2",
+          "pkgId": "st@1.2.2",
+          "deps": [
+            {
+              "nodeId": "async-cache@1.1.0"
+            },
+            {
+              "nodeId": "bl@1.2.2"
+            },
+            {
+              "nodeId": "fd@0.0.3"
+            },
+            {
+              "nodeId": "graceful-fs@4.1.15"
+            },
+            {
+              "nodeId": "mime@1.4.1"
+            },
+            {
+              "nodeId": "negotiator@0.6.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "stream-buffers@3.0.2",
+          "pkgId": "stream-buffers@3.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-styles@2.2.1",
+          "pkgId": "ansi-styles@2.2.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "has-ansi@2.0.0",
+          "pkgId": "has-ansi@2.0.0",
+          "deps": [
+            {
+              "nodeId": "ansi-regex@2.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "supports-color@2.0.0",
+          "pkgId": "supports-color@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "chalk@1.1.3",
+          "pkgId": "chalk@1.1.3",
+          "deps": [
+            {
+              "nodeId": "ansi-styles@2.2.1"
+            },
+            {
+              "nodeId": "escape-string-regexp@1.0.5"
+            },
+            {
+              "nodeId": "has-ansi@2.0.0"
+            },
+            {
+              "nodeId": "strip-ansi@3.0.1"
+            },
+            {
+              "nodeId": "supports-color@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "js-tokens@3.0.2",
+          "pkgId": "js-tokens@3.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "babel-code-frame@6.26.0",
+          "pkgId": "babel-code-frame@6.26.0",
+          "deps": [
+            {
+              "nodeId": "chalk@1.1.3"
+            },
+            {
+              "nodeId": "esutils@2.0.3"
+            },
+            {
+              "nodeId": "js-tokens@3.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "colors@1.4.0",
+          "pkgId": "colors@1.4.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "diff@3.5.0",
+          "pkgId": "diff@3.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "glob@5.0.15",
+          "pkgId": "glob@5.0.15",
+          "deps": [
+            {
+              "nodeId": "inflight@1.0.6"
+            },
+            {
+              "nodeId": "inherits@2.0.3"
+            },
+            {
+              "nodeId": "minimatch@3.0.4"
+            },
+            {
+              "nodeId": "once@1.4.0"
+            },
+            {
+              "nodeId": "path-is-absolute@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "findup-sync@0.3.0",
+          "pkgId": "findup-sync@0.3.0",
+          "deps": [
+            {
+              "nodeId": "glob@5.0.15"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "minimist@0.0.10",
+          "pkgId": "minimist@0.0.10",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "wordwrap@0.0.3",
+          "pkgId": "wordwrap@0.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "optimist@0.6.1",
+          "pkgId": "optimist@0.6.1",
+          "deps": [
+            {
+              "nodeId": "minimist@0.0.10"
+            },
+            {
+              "nodeId": "wordwrap@0.0.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "path-parse@1.0.6",
+          "pkgId": "path-parse@1.0.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "resolve@1.8.1",
+          "pkgId": "resolve@1.8.1",
+          "deps": [
+            {
+              "nodeId": "path-parse@1.0.6"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tsutils@1.9.1",
+          "pkgId": "tsutils@1.9.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tslint@5.1.0",
+          "pkgId": "tslint@5.1.0",
+          "deps": [
+            {
+              "nodeId": "babel-code-frame@6.26.0"
+            },
+            {
+              "nodeId": "colors@1.4.0"
+            },
+            {
+              "nodeId": "diff@3.5.0"
+            },
+            {
+              "nodeId": "findup-sync@0.3.0"
+            },
+            {
+              "nodeId": "glob@7.1.3"
+            },
+            {
+              "nodeId": "optimist@0.6.1"
+            },
+            {
+              "nodeId": "resolve@1.8.1"
+            },
+            {
+              "nodeId": "semver@5.6.0"
+            },
+            {
+              "nodeId": "tsutils@1.9.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/utils/utils.test.ts
+++ b/test/utils/utils.test.ts
@@ -6,7 +6,6 @@ afterEach(() => {
   mockAxios.reset();
 });
 
-
 const fixtures = fs.readFileSync('test/fixtures/utils/allProjects.json');
 
 describe('Testing utils', () => {

--- a/tsconfig-generators-and-abstraction.json
+++ b/tsconfig-generators-and-abstraction.json
@@ -15,6 +15,7 @@
   "include": [
     "./src/lib/generators/*",
     "./src/lib/preprocessors/*",
-    "./src/lib/utils/*"
+    "./src/lib/utils/*",
+    "./src/lib/client/abstraction/**/*"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,16 +2,15 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "es2017",
+    "target": "es2019",
     "module": "commonjs",
     "sourceMap": true,
     "declaration": true,
     "importHelpers": true,
     "strict": true,
     "esModuleInterop": true,
-    "lib": [
-      "esnext"
-    ],
+    "lib": ["esnext"],
+    "types": ["node", "jest"]
   },
   "include": ["./src/lib/**/*"]
 }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds mechanism to create helper functions in the abstraction folders which then get picked up by the generator code to add as extra method to the corresponding class.

In the abstraction folder, subfolders must match the generated client. In this case, we are adding new methods to the aggregatedissues class under org. Therefore the folder is abstraction/org/aggregatedissues.ts.
The path is critical as the generator infers information as to where to put this code from this folder structure.

In the helper file:
export type or interface for whatever you need.
export the function(s) you want to have injected in the corresponding class.
```export const myFunction = async (classContext: Object, whateverArg: ArgType): Promise<ReturnType> => {
....
}```
The code above is the most expected setup (most likely async).
classContext will contain the necessary information to get the orgId, projectId and other things being built as you create a new Org({orgId: '123'}).project({projectId: 'abc'}).... 123 and abc become available via the classContext object (for example: `Object(classContext)['projectId']` )

### Notes for the reviewer

Please review the PR and especially the aggregatedissues.ts in the abstraction/org folder for a good example.

### More information

Better documentation soon, promised !
