### PR TITLE
fix: remove qs from endpoint name and swap nolimitmode flag

### DIFF
--- a/src/lib/generators/generate.ts
+++ b/src/lib/generators/generate.ts
@@ -67,6 +67,7 @@ const generateClass = (
   abstractionImportsArray.push(
     generateImportsForAbstractionMethods(classToGenerate),
   );
+  abstractionImportsArray = [...new Set(abstractionImportsArray)];
 
   if (classToGenerate) {
     if (isRootClass) {
@@ -777,7 +778,7 @@ const generatePaginationMethods = (
         method.argsList = method.argsList
           .filter((x) => !x.startsWith('perPage'))
           .filter((x) => !x.startsWith('page'));
-        method.argsList.unshift('noLimitMode: boolean = false');
+        method.argsList.push('noLimitMode: boolean = false');
 
         let qsIfStatements = '';
         qsParametersNamesList.forEach((qsParameterName) => {
@@ -1004,6 +1005,6 @@ parsedJSON.forEach((classItem) => {
   const classCode = generateClass(classItem);
   fs.writeFileSync(
     path.join('./src/lib/client/generated/' + classItem.name + '.ts'),
-    initLines + abstractionImportsArray.join(`\n`) + classCode,
+    initLines + abstractionImportsArray.join(`\n`) + '\n' + classCode,
   );
 });

--- a/src/lib/preprocessors/prepare.ts
+++ b/src/lib/preprocessors/prepare.ts
@@ -330,7 +330,10 @@ const main = (jsonPath: string) => {
   paths = consolidateReferences(paths);
   Object.keys(paths).forEach((path) => {
     const verbs = Object.keys(paths[path]);
-    const splitEndpoint = path.split('/').filter((x) => x);
+    const splitEndpoint = path
+      .split('?')[0]
+      .split('/')
+      .filter((x) => x);
     classMap = registerEndpoint(
       classMap,
       extractClassAndParamFromEndpoint(splitEndpoint, verbs, path),


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Sanitize data from APIB converted to swagger better for endpoint names.
Swap noLimitFlag to be at the end of the method call, facilitating automatic test cases code generation.

### Notes for the reviewer

This code fixes a few issues but will not work till the API blueprint syntax is fixed in a few places.
