### PR TITLE
chore: pin axios to 022 before breaking changes in minor versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@snyk/dep-graph": "^1.23.0",
     "@types/lodash": "^4.14.155",
     "@types/node": "^14.0.12",
-    "axios": "^0.24.0",
+    "axios": "0.22.0",
     "debug": "^4.1.1",
     "jsonq": "^1.2.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Pins axios to 0.22 before breaking changes in 0.23 and 0.24 going in, despite minor semver bump only....
