### PR TITLE
chore: mark as not maintained

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ jobs:
             - image: circleci/node:latest
         steps:
             - checkout
-            #- run: npm install semantic-release @semantic-release/exec pkg --save-dev
             - run: npm install
             - run: curl https://snyk.docs.apiary.io/api-description-document -o snyk.apib
             - run: ./prepare-apib.sh snyk.apib
@@ -23,10 +22,6 @@ jobs:
             - run: npm run generate-test-fixtures
             - run: npm run format
             - run: npm test
-            - snyk/scan:
-                fail-on-issues: true
-                monitor-on-build: true
-                token-variable: SNYK_TOKEN
             - run: npm run clean-generated-classes
             - run: npm run generate-classes
             - run: npm run clean-for-release
@@ -51,10 +46,6 @@ jobs:
             - run: npm run generate-test-fixtures
             - run: npm run format
             - run: npm test
-            - snyk/scan:
-                fail-on-issues: true
-                monitor-on-build: false
-                token-variable: SNYK_TOKEN
     build-test-from-fork:
         docker:
             - image: circleci/node:latest

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ snyk-prepared.json
 *.bak
 test/fixtures/*.json
 test/lib/*.test.ts
+.dccache

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 ***
 
 [![Known Vulnerabilities](https://snyk.io/test/github/snyk-tech-services/snyk-api-ts-client/badge.svg)](https://snyk.io/test/github/snyk-tech-services/snyk-api-ts-client)
+[![Not Maintained](https://img.shields.io/badge/Maintenance%20Level-Not%20Maintained-yellow.svg)](https://gist.github.com/cheerfulstoic/d107229326a01ff0f333a1d3476e068d)
 
-# Documentation based generated Snyk Api Typescript client
+**This repository is not in active development and critical bug fixes only will be considered.**
 
-Taking as input a swagger definition we convert from the api blueprint, it generates a client for all Snyk API v1 endpoints.  
+# Documentation based generated Snyk API TypeScript client
+
+Taking as input a swagger definition we convert from the api blueprint, it generates a client for all Snyk API v1 endpoints.
 APIv3 endpoints are currently not supported.
 
 Generated from [Snyk APIs](https://snyk.docs.apiary.io/)
@@ -52,7 +55,7 @@ main()
 Pass a boolean true/false to see the full response or just the data. Default is false, showing you only the response body.
 
 
-### Endpoint Deprecation Notes
-As of 1.7.3, the `/issues` endpoint is decommissioned. The `aggregated-issues` endpoint is the replacement to use.  
-Vulnerable paths can be retrieved using the [paths endpoint](https://snyk.docs.apiary.io/#reference/projects/project-issue-paths/list-all-project-issue-paths) which also contain the `fixVersion` info to know how to fix that particular path.  
+### Endpoint deprecation notice
+As of 1.7.3, the `/issues` endpoint is decommissioned. The `aggregated-issues` endpoint is the replacement to use.
+Vulnerable paths can be retrieved using the [paths endpoint](https://snyk.docs.apiary.io/#reference/projects/project-issue-paths/list-all-project-issue-paths) which also contain the `fixVersion` info to know how to fix that particular path.
 The supporting methods are available in the client generated.


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
- Mark repo as no longer actively maintained
- Remove snyk/scan in favour of PR checks
- spelling fixes