### PR TITLE
fix: bump node version in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
     build-test-monitor:
         docker:
-            - image: cimg/node:18.16.0
+            - image: cimg/node:18.17.1
         steps:
             - checkout
             - run: npm install
@@ -28,7 +28,7 @@ jobs:
             - run: npx semantic-release
     build-test:
         docker:
-            - image: cimg/node:18.16.0
+            - image: cimg/node:18.17.1
         steps:
             - checkout
             - run: npm install
@@ -48,7 +48,7 @@ jobs:
             - run: npm test
     build-test-from-fork:
         docker:
-            - image: cimg/node:18.16.0
+            - image: cimg/node:18.17.1
         steps:
             - checkout
             - run: npm install


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Aligns required node version