### PR TITLE
chore(docs): Correct api docs location

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Taking as input a swagger definition we convert from the api blueprint, it generates a client for all Snyk API v1 endpoints.
 APIv3 endpoints are currently not supported.
 
-Generated from [Snyk APIs](https://snyk.docs.apiary.io/)
+Generated from [Snyk APIs](https://docs.snyk.io/snyk-api/reference)
 
 ## Requirements
 Node 14 or above
@@ -23,7 +23,7 @@ Node 14 or above
 
 ## Usage
 
-Find which endpoint is of interest to you in the [API Reference](https://snyk.docs.apiary.io/).\
+Find which endpoint is of interest to you in the [API Reference](https://docs.snyk.io/snyk-api/reference).\
 Then import and use.
 
 ```
@@ -58,5 +58,5 @@ Pass a boolean true/false to see the full response or just the data. Default is 
 
 ### Endpoint deprecation notice
 As of 1.7.3, the `/issues` endpoint is decommissioned. The `aggregated-issues` endpoint is the replacement to use.
-Vulnerable paths can be retrieved using the [paths endpoint](https://snyk.docs.apiary.io/#reference/projects/project-issue-paths/list-all-project-issue-paths) which also contain the `fixVersion` info to know how to fix that particular path.
+Vulnerable paths can be retrieved using the [paths endpoint](https://docs.snyk.io/snyk-api/reference#reference/projects/project-issue-paths/list-all-project-issue-paths) which also contain the `fixVersion` info to know how to fix that particular path.
 The supporting methods are available in the client generated.


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [X] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Previously the Snyk api docs were at <https://snyk.docs.apiary.io/> and this states that it was sunset in favour of <https://docs.snyk.io/snyk-api/v1-api> and <https://docs.snyk.io/snyk-api/reference>

<img width="935" height="660" alt="Screenshot 2026-02-23 at 13 33 27" src="https://github.com/user-attachments/assets/0cbab9d3-b9d2-4b66-b35f-35203533620f" />


This PR updates the readme to point to the non-sunset link


### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [Link to documentation](https://github.com/snyk/snyk-api-ts-client/wiki/)

### Screenshots

_Visuals that may help the reviewer_
